### PR TITLE
Update to DMD 2.076.0

### DIFF
--- a/ds/source/testscript.d
+++ b/ds/source/testscript.d
@@ -21,7 +21,7 @@ import std.path;
 import std.file;
 import std.stdio;
 import std.exception;
-import std.c.stdlib;
+import core.stdc.stdlib;
 import core.memory;
 
 import dmdscript.script;

--- a/engine/source/dmdscript/darray.d
+++ b/engine/source/dmdscript/darray.d
@@ -23,7 +23,7 @@ module dmdscript.darray;
 version =  SliceSpliceExtension;
 
 import std.string;
-import std.c.stdlib;
+import core.stdc.stdlib;
 import std.math;
 
 import dmdscript.script;
@@ -739,7 +739,7 @@ void *Darray_prototype_sort(Dobject pthis, CallContext *cc, Dobject othis, Value
         }
 
         // Sort pvalues[]
-        std.c.stdlib.qsort(pvalues.ptr, nprops, Value.sizeof, &compare_value);
+        core.stdc.stdlib.qsort(pvalues.ptr, nprops, Value.sizeof, &compare_value);
 
         comparefn = null;
         comparecc = null;

--- a/engine/source/dmdscript/darray.d
+++ b/engine/source/dmdscript/darray.d
@@ -596,7 +596,7 @@ else{//Canonical ECMA all kinds of infinity maped to 0
 static Dobject comparefn;
 static CallContext *comparecc;
 
-extern (C) int compare_value(const void* x, const void* y)
+extern (C) int compare_value(scope const void* x, scope const void* y)
 {
     Value* vx = cast(Value*)x;
     Value* vy = cast(Value*)y;

--- a/engine/source/dmdscript/ddeclaredfunction.d
+++ b/engine/source/dmdscript/ddeclaredfunction.d
@@ -18,7 +18,7 @@
 module dmdscript.ddeclaredfunction;
 
 import std.stdio;
-import std.c.stdlib;
+import core.stdc.stdlib;
 import std.exception;
 import dmdscript.script;
 import dmdscript.dobject;

--- a/engine/source/dmdscript/dfunction.d
+++ b/engine/source/dmdscript/dfunction.d
@@ -19,7 +19,7 @@
 module dmdscript.dfunction;
 
 import std.string;
-import std.c.stdlib;
+import core.stdc.stdlib;
 
 import dmdscript.script;
 import dmdscript.dobject;

--- a/engine/source/dmdscript/dglobal.d
+++ b/engine/source/dmdscript/dglobal.d
@@ -18,8 +18,8 @@
 module dmdscript.dglobal;
 
 import std.uri;
-import std.c.stdlib;
-import std.c.string;
+import core.stdc.stdlib;
+import core.stdc.string;
 import std.stdio;
 import std.algorithm;
 import std.math;
@@ -178,6 +178,8 @@ Lsyntaxerror:
 
 void* Dglobal_parseInt(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value[] arglist)
 {
+    static import std.utf;
+
     // ECMA 15.1.2.2
     Value* v2;
     immutable(char) * s;
@@ -325,6 +327,8 @@ tchar[16 + 1] TOHEX = "0123456789ABCDEF";
 
 void* Dglobal_escape(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value[] arglist)
 {
+    import std.string : indexOf;
+
     // ECMA 15.1.2.4
     d_string s;
     uint escapes;
@@ -340,7 +344,7 @@ void* Dglobal_escape(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, 
         if(c >= 0x100)
             unicodes++;
         else
-        if(c == 0 || c >= 0x80 || (!ISURIALNUM(c) && std.string.indexOf("*@-_+./", c) == -1))
+        if(c == 0 || c >= 0x80 || (!ISURIALNUM(c) && indexOf("*@-_+./", c) == -1))
             escapes++;
     }
     if((escapes + unicodes) == 0)
@@ -365,7 +369,7 @@ void* Dglobal_escape(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, 
                 r[5] = TOHEX[c & 15];
                 r += 6;
             }
-            else if(c == 0 || c >= 0x80 || (!ISURIALNUM(c) && std.string.indexOf("*@-_+./", c) == -1))
+            else if(c == 0 || c >= 0x80 || (!ISURIALNUM(c) && indexOf("*@-_+./", c) == -1))
             {
                 r[0] = '%';
                 r[1] = TOHEX[c >> 4];
@@ -388,6 +392,8 @@ void* Dglobal_escape(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, 
 
 void* Dglobal_unescape(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value[] arglist)
 {
+    static import dmdscript.utf;
+
     // ECMA 15.1.2.5
     d_string s;
     d_string R;
@@ -629,6 +635,8 @@ void* Dglobal_println(Dobject pthis, CallContext *cc, Dobject othis, Value* ret,
 
 void* Dglobal_readln(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value[] arglist)
 {
+    static import dmdscript.utf;
+
     // Our own extension
     dchar c;
     d_string s;
@@ -637,25 +645,25 @@ void* Dglobal_readln(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, 
     {
         version(linux)
         {
-            c = std.c.stdio.getchar();
+            c = core.stdc.stdio.getchar();
             if(c == EOF)
                 break;
         }
         else version(Windows)
         {
-            c = std.c.stdio.getchar();
+            c = core.stdc.stdio.getchar();
             if(c == EOF)
                 break;
         }
         else version(OSX)
         {
-            c = std.c.stdio.getchar();
+            c = core.stdc.stdio.getchar();
             if(c == EOF)
                 break;
         }
         else version(FreeBSD)
         {
-            c = std.c.stdio.getchar();
+            c = core.stdc.stdio.getchar();
             if(c == EOF)
                 break;
         }
@@ -675,12 +683,14 @@ void* Dglobal_readln(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, 
 
 void* Dglobal_getenv(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value[] arglist)
 {
+    import std.string : toStringz;
+
     // Our own extension
     ret.putVundefined();
     if(arglist.length)
     {
         d_string s = arglist[0].toString();
-        char* p = getenv(std.string.toStringz(s));
+        char* p = getenv(toStringz(s));
         if(p)
             ret.putVstring(p[0 .. strlen(p)].idup);
         else

--- a/engine/source/dmdscript/dnumber.d
+++ b/engine/source/dmdscript/dnumber.d
@@ -18,7 +18,7 @@
 module dmdscript.dnumber;
 
 import std.math;
-import std.c.stdlib;
+import core.stdc.stdlib;
 import std.exception;
 
 import dmdscript.script;
@@ -219,6 +219,8 @@ number_t deconstruct_real(d_number x, int f, out int pe)
 
 void* Dnumber_prototype_toFixed(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
+    import std.format : sformat;
+
     // ECMA v3 15.7.4.5
     Value* v;
     d_number x;
@@ -287,7 +289,7 @@ void* Dnumber_prototype_toFixed(Dobject pthis, CallContext *cc, Dobject othis, V
             else
             {
                 // n still doesn't give 20 digits, only 19
-                m = std.string.sformat(buffer[], "%d", cast(ulong)n);
+                m = sformat(buffer[], "%d", cast(ulong)n);
                 dup = 1;
             }
             if(f != 0)
@@ -340,6 +342,8 @@ void* Dnumber_prototype_toFixed(Dobject pthis, CallContext *cc, Dobject othis, V
 
 void* Dnumber_prototype_toExponential(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
+    import std.format : format, sformat;
+
     // ECMA v3 15.7.4.6
     Value* varg;
     Value* v;
@@ -447,7 +451,7 @@ void* Dnumber_prototype_toExponential(Dobject pthis, CallContext *cc, Dobject ot
                     }
                 }
                 // n still doesn't give 20 digits, only 19
-                m = std.string.sformat(buffer[], "%d", cast(ulong)n);
+                m = sformat(buffer[], "%d", cast(ulong)n);
             }
             if(f)
             {
@@ -465,7 +469,7 @@ void* Dnumber_prototype_toExponential(Dobject pthis, CallContext *cc, Dobject ot
             // result = sign + m + "e" + c + e;
             d_string c = (e >= 0) ? "+" : "";
 
-            result = std.string.format("%s%se%s%d", sign ? "-" : "", m, c, e);
+            result = format("%s%se%s%d", sign ? "-" : "", m, c, e);
         }
     }
 
@@ -477,6 +481,8 @@ void* Dnumber_prototype_toExponential(Dobject pthis, CallContext *cc, Dobject ot
 
 void* Dnumber_prototype_toPrecision(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
+    import std.format : format, sformat;
+
     // ECMA v3 15.7.4.7
     Value* varg;
     Value* v;
@@ -547,13 +553,13 @@ void* Dnumber_prototype_toPrecision(Dobject pthis, CallContext *cc, Dobject othi
                 n = deconstruct_real(x, p - 1, e);
 
                 // n still doesn't give 20 digits, only 19
-                m = std.string.sformat(buffer[], "%d", cast(ulong)n);
+                m = sformat(buffer[], "%d", cast(ulong)n);
 
                 if(e < -6 || e >= p)
                 {
                     // result = sign + m[0] + "." + m[1 .. p] + "e" + c + e;
                     d_string c = (e >= 0) ? "+" : "";
-                    result = std.string.format("%s%s.%se%s%d",
+                    result = format("%s%s.%se%s%d",
                                                (sign ? "-" : ""), m[0], m[1 .. $], c, e);
                     goto Ldone;
                 }

--- a/engine/source/dmdscript/dobject.d
+++ b/engine/source/dmdscript/dobject.d
@@ -584,12 +584,12 @@ class Dobject
             *perrinfo = errinfo;
     }
 
-    static Value* RuntimeError(ErrInfo *perrinfo, int msgnum)
+    static Value* RuntimeError(ARGS...)(ErrInfo *perrinfo, int msgnum, ARGS args)
     {
-        return RuntimeError(perrinfo, errmsgtbl[msgnum]);
+        return RuntimeError(perrinfo, errmsgtbl[msgnum], args);
     }
 
-    static Value* RuntimeError(ErrInfo *perrinfo, ...)
+    static Value* RuntimeError(ARGS...)(ErrInfo *perrinfo, string fmt, ARGS args)
     {
         Dobject o;
 
@@ -601,22 +601,27 @@ class Dobject
             std.utf.encode(buffer, c);
         }
 
-        std.format.doFormat(&putc, _arguments, _argptr);
+        std.format.formattedWrite(&putc, fmt, args);
         perrinfo.message = assumeUnique(buffer);
         o = new typeerror.D0(perrinfo);
         Value* v = new Value;
         v.putVobject(o);
         return v;
     }
-    static Value* ReferenceError(ErrInfo *perrinfo, int msgnum)
+    static Value* ReferenceError(ARGS...)(ErrInfo *perrinfo, int msgnum, ARGS args)
     {
-        return ReferenceError(perrinfo, errmsgtbl[msgnum]);
+        return ReferenceError(perrinfo, errmsgtbl[msgnum], args);
     }
 
-    static Value* ReferenceError(...)
+    static Value* ReferenceError(ARGS...)(string fmt, ARGS args)
+    {
+        ErrInfo errinfo;
+        return ReferenceError(&errinfo, fmt, args);
+    }
+
+    static Value* ReferenceError(ARGS...)(ErrInfo* perrinfo, string fmt, ARGS args)
     {
         Dobject o;
-        ErrInfo errinfo;
         //perrinfo.message = null;
         d_string buffer = null;
 
@@ -625,20 +630,21 @@ class Dobject
             dmdscript.utf.encode(buffer, c);
         }
 
-        std.format.doFormat(&putc, _arguments, _argptr);
-        errinfo.message = buffer;
+        std.format.formattedWrite(&putc, fmt, args);
+        perrinfo.message = buffer;
 
-        o = new referenceerror.D0(&errinfo);
+        o = new referenceerror.D0(perrinfo);
         Value* v = new Value;
         v.putVobject(o);
+
         return v;
     }
-    static Value* RangeError(ErrInfo *perrinfo, int msgnum)
+    static Value* RangeError(ARGS...)(ErrInfo *perrinfo, int msgnum, ARGS args)
     {
-        return RangeError(perrinfo, errmsgtbl[msgnum]);
+        return RangeError(perrinfo, errmsgtbl[msgnum], args);
     }
 
-    static Value* RangeError(ErrInfo *perrinfo, ...)
+    static Value* RangeError(ARGS...)(ErrInfo *perrinfo, string fmt, ARGS args)
     {
         Dobject o;
 
@@ -650,7 +656,7 @@ class Dobject
             dmdscript.utf.encode(buffer, c);
         }
 
-        std.format.doFormat(&putc, _arguments, _argptr);
+        std.format.formattedWrite(&putc, fmt, args);
         perrinfo.message = buffer;
 
         o = new rangeerror.D0(perrinfo);

--- a/engine/source/dmdscript/dobject.d
+++ b/engine/source/dmdscript/dobject.d
@@ -18,8 +18,8 @@
 module dmdscript.dobject;
 
 import std.string;
-import std.c.stdarg;
-import std.c.string;
+import core.stdc.stdarg;
+import core.stdc.string;
 import std.exception;
 
 import dmdscript.script;
@@ -591,6 +591,8 @@ class Dobject
 
     static Value* RuntimeError(ARGS...)(ErrInfo *perrinfo, string fmt, ARGS args)
     {
+        import std.format : formattedWrite;
+
         Dobject o;
 
         //perrinfo.message = null;
@@ -601,7 +603,7 @@ class Dobject
             std.utf.encode(buffer, c);
         }
 
-        std.format.formattedWrite(&putc, fmt, args);
+        formattedWrite(&putc, fmt, args);
         perrinfo.message = assumeUnique(buffer);
         o = new typeerror.D0(perrinfo);
         Value* v = new Value;
@@ -621,6 +623,8 @@ class Dobject
 
     static Value* ReferenceError(ARGS...)(ErrInfo* perrinfo, string fmt, ARGS args)
     {
+        import std.format : formattedWrite;
+
         Dobject o;
         //perrinfo.message = null;
         d_string buffer = null;
@@ -630,7 +634,7 @@ class Dobject
             dmdscript.utf.encode(buffer, c);
         }
 
-        std.format.formattedWrite(&putc, fmt, args);
+        formattedWrite(&putc, fmt, args);
         perrinfo.message = buffer;
 
         o = new referenceerror.D0(perrinfo);
@@ -646,6 +650,8 @@ class Dobject
 
     static Value* RangeError(ARGS...)(ErrInfo *perrinfo, string fmt, ARGS args)
     {
+        import std.format : formattedWrite;
+
         Dobject o;
 
         //perrinfo.message = null;
@@ -656,7 +662,7 @@ class Dobject
             dmdscript.utf.encode(buffer, c);
         }
 
-        std.format.formattedWrite(&putc, fmt, args);
+        formattedWrite(&putc, fmt, args);
         perrinfo.message = buffer;
 
         o = new rangeerror.D0(perrinfo);

--- a/engine/source/dmdscript/dregexp.d
+++ b/engine/source/dmdscript/dregexp.d
@@ -251,6 +251,8 @@ class DregexpConstructor : Dfunction
     // Translate Perl property names to script property names
     static d_string perlAlias(d_string s)
     {
+        import std.algorithm.searching : countUntil;
+
         d_string t;
 
         static immutable tchar[] from = "_*&+`'";
@@ -269,7 +271,7 @@ class DregexpConstructor : Dfunction
         {
             ptrdiff_t i;
 
-            i = std.algorithm.countUntil(from, s[1]);
+            i = countUntil(from, s[1]);
             if(i >= 0)
                 t = to[i];
         }

--- a/engine/source/dmdscript/dregexp.d
+++ b/engine/source/dmdscript/dregexp.d
@@ -213,7 +213,7 @@ class DregexpConstructor : Dfunction
     }
 
 
-    override Value* Get(d_string PropertyName) const
+    override Value* Get(d_string PropertyName)
     {
         return Dfunction.Get(perlAlias(PropertyName));
     }

--- a/engine/source/dmdscript/expression.d
+++ b/engine/source/dmdscript/expression.d
@@ -279,6 +279,9 @@ class NullExpression : Expression
 
 class StringExpression : Expression
 {
+    static import std.ascii;
+    import std.format : format;
+
     d_string string;
 
     this(Loc loc, d_string string)
@@ -302,11 +305,11 @@ class StringExpression : Expression
             default:
                 Ldefault:
                 if(c & ~0xFF)
-                    buf ~= std.string.format("\\u%04x", c);
+                    buf ~= format("\\u%04x", c);
                 else if(std.ascii.isPrintable(c))
                     buf ~= cast(tchar)c;
                 else
-                    buf ~= std.string.format("\\x%02x", c);
+                    buf ~= format("\\x%02x", c);
                 break;
             }
         }

--- a/engine/source/dmdscript/irstate.d
+++ b/engine/source/dmdscript/irstate.d
@@ -18,9 +18,9 @@
 
 module dmdscript.irstate;
 
-import std.c.stdarg;
-import std.c.stdlib;
-import std.c.string;
+import core.stdc.stdarg;
+import core.stdc.stdlib;
+import core.stdc.string;
 import dmdscript.outbuffer;
 import core.memory;
 import core.stdc.stdio;

--- a/engine/source/dmdscript/lexer.d
+++ b/engine/source/dmdscript/lexer.d
@@ -27,7 +27,7 @@ import std.string;
 import std.utf;
 import std.outbuffer;
 import std.ascii;
-import std.c.stdlib;
+import core.stdc.stdlib;
 
 import dmdscript.script;
 import dmdscript.text;
@@ -260,11 +260,12 @@ class Lexer
 
     this(d_string sourcename, d_string base, int useStringtable)
     {
+        import core.stdc.string : memset;
         //writefln("Lexer::Lexer(base = '%s')\n",base);
         if(!inited)
             init();
 
-        std.c.string.memset(&token, 0, token.sizeof);
+        memset(&token, 0, token.sizeof);
         this.useStringtable = useStringtable;
         this.sourcename = sourcename;
         if(!base.length || (base[$ - 1] != 0 && base[$ - 1] != 0x1A))
@@ -307,6 +308,8 @@ class Lexer
 
     void error(ARGS...)(.string fmt, ARGS args)
     {
+        import std.format : format, formattedWrite;
+
         uint linnum = 1;
         immutable(tchar) * s;
         immutable(tchar) * slinestart;
@@ -344,14 +347,14 @@ class Lexer
         }
         slineend = s;
 
-        buf = std.string.format("%s(%d) : Error: ", sourcename, linnum);
+        buf = format("%s(%d) : Error: ", sourcename, linnum);
 
         void putc(dchar c)
         {
             dmdscript.utf.encode(buf, c);
         }
 
-        std.format.formattedWrite(&putc, fmt, args);
+        formattedWrite(&putc, fmt, args);
 
         if(!errinfo.message)
         {
@@ -496,6 +499,9 @@ class Lexer
 
     void scan(Token *t)
     {
+        static import std.ascii;
+        static import std.uni;
+
         tchar c;
         dchar d;
         d_string id;
@@ -1452,7 +1458,7 @@ class Lexer
 
                 Ldouble:
                 // convert double
-                realvalue = std.c.stdlib.strtod(toStringz(start[0 .. p - start]), null);
+                realvalue = core.stdc.stdlib.strtod(toStringz(start[0 .. p - start]), null);
                 t.realvalue = realvalue;
                 return TOKreal;
             }

--- a/engine/source/dmdscript/lexer.d
+++ b/engine/source/dmdscript/lexer.d
@@ -300,12 +300,12 @@ class Lexer
         return base.ptr + idx;
     }
 
-    void error(int msgnum)
+    void error(ARGS...)(int msgnum, ARGS args)
     {
-        error(errmsgtbl[msgnum]);
+        error(errmsgtbl[msgnum], args);
     }
 
-    void error(...)
+    void error(ARGS...)(.string fmt, ARGS args)
     {
         uint linnum = 1;
         immutable(tchar) * s;
@@ -351,7 +351,7 @@ class Lexer
             dmdscript.utf.encode(buf, c);
         }
 
-        std.format.doFormat(&putc, _arguments, _argptr);
+        std.format.formattedWrite(&putc, fmt, args);
 
         if(!errinfo.message)
         {

--- a/engine/source/dmdscript/outbuffer.d
+++ b/engine/source/dmdscript/outbuffer.d
@@ -21,9 +21,9 @@ private
 {
     import core.memory;
     import std.string;
-    import std.c.stdio;
-    import std.c.stdlib;
-    import std.c.stdarg;
+    import core.stdc.stdio;
+    import core.stdc.stdlib;
+    import core.stdc.stdarg;
 }
 
 /*********************************************

--- a/engine/source/dmdscript/program.d
+++ b/engine/source/dmdscript/program.d
@@ -19,7 +19,7 @@
 module dmdscript.program;
 
 import std.stdio;
-import std.c.stdlib;
+import core.stdc.stdlib;
 
 import dmdscript.script;
 import dmdscript.dobject;

--- a/engine/source/dmdscript/property.d
+++ b/engine/source/dmdscript/property.d
@@ -24,7 +24,7 @@ import dmdscript.identifier;
 
 import dmdscript.RandAA;
 
-import std.c.string;
+import core.stdc.string;
 import std.stdio;
 
 // attribute flags

--- a/engine/source/dmdscript/script.d
+++ b/engine/source/dmdscript/script.d
@@ -115,14 +115,12 @@ Global global;
 
 string banner()
 {
-    return std.string.format(
-               "DMDSsript-2 v0.1rc1\n",
-               "Compiled by Digital Mars DMD D compiler\n" ~
-               "http://www.digitalmars.com\n",
-               "Fork of the original DMDScript 1.16\n",
-               global.written,"\n",
-               global.copyright
-               );
+    return  "DMDSsript-2 v0.1rc1\n" ~
+            "Compiled by Digital Mars DMD D compiler\n" ~
+            "http://www.digitalmars.com\n" ~
+            "Fork of the original DMDScript 1.16\n" ~
+            global.written ~ "\n" ~
+            global.copyright;
 }
 
 int isStrWhiteSpaceChar(dchar c)

--- a/engine/source/dmdscript/script.d
+++ b/engine/source/dmdscript/script.d
@@ -206,6 +206,8 @@ int StringToIndex(d_string name, out d_uint32 index)
 
 d_number StringNumericLiteral(d_string string, out size_t endidx, int parsefloat)
 {
+    import core.stdc.stdlib : strtod;
+
     // Convert StringNumericLiteral using ECMA 9.3.1
     d_number number;
     int sign = 0;
@@ -289,11 +291,11 @@ d_number StringNumericLiteral(d_string string, out size_t endidx, int parsefloat
     }
     else
     {
-        char* endptr;
+        const(char)* endptr;
         const (char) * s = std.string.toStringz(string[i .. len]);
 
         //endptr = s;//Fixed: No need to fill endptr prior to stdtod
-        number = std.c.stdlib.strtod(s, &endptr);
+        number = strtod(s, &endptr);
         endidx = (endptr - s) + i;
 
         //printf("s = '%s', endidx = %d, eoff = %d, number = %g\n", s, endidx, eoff, number);

--- a/engine/source/dmdscript/script.d
+++ b/engine/source/dmdscript/script.d
@@ -19,8 +19,8 @@ module dmdscript.script;
 
 import std.ascii;
 import std.string;
-import std.c.stdlib;
-import std.c.stdarg;
+import core.stdc.stdlib;
+import core.stdc.stdarg;
 
 /* =================== Configuration ======================= */
 
@@ -117,7 +117,7 @@ string banner()
 {
     return std.string.format(
                "DMDSsript-2 v0.1rc1\n",
-               "Compiled by Digital Mars DMD D compiler\n"
+               "Compiled by Digital Mars DMD D compiler\n" ~
                "http://www.digitalmars.com\n",
                "Fork of the original DMDScript 1.16\n",
                global.written,"\n",

--- a/engine/source/dmdscript/statement.d
+++ b/engine/source/dmdscript/statement.d
@@ -91,6 +91,9 @@ class TopStatement
 
     void error(ARGS...)(Scope *sc, string fmt, ARGS args)
     {
+        static import dmdscript.utf;
+        import std.format : formattedWrite;
+
         d_string buf;
         d_string sourcename;
 
@@ -108,7 +111,7 @@ class TopStatement
             dmdscript.utf.encode(buf, c);
         }
 
-        std.format.formattedWrite(&putc, fmt, args);
+        formattedWrite(&putc, fmt, args);
 
 
         if(!sc.errinfo.message)

--- a/engine/source/dmdscript/statement.d
+++ b/engine/source/dmdscript/statement.d
@@ -84,12 +84,12 @@ class TopStatement
         writefln("TopStatement.toIR(%p)", this);
     }
 
-    void error(Scope *sc, int msgnum)
+    void error(ARGS...)(Scope *sc, int msgnum, ARGS args)
     {
-        error(sc, errmsgtbl[msgnum]);
+        error(sc, errmsgtbl[msgnum], args);
     }
 
-    void error(Scope *sc, ...)
+    void error(ARGS...)(Scope *sc, string fmt, ARGS args)
     {
         d_string buf;
         d_string sourcename;
@@ -108,7 +108,7 @@ class TopStatement
             dmdscript.utf.encode(buf, c);
         }
 
-        std.format.doFormat(&putc, _arguments, _argptr);
+        std.format.formattedWrite(&putc, fmt, args);
 
 
         if(!sc.errinfo.message)

--- a/engine/source/dmdscript/value.d
+++ b/engine/source/dmdscript/value.d
@@ -21,7 +21,7 @@ import undead.date;
 import std.math;
 import std.string;
 import std.stdio;
-import std.c.string;
+import core.stdc.string;
 
 import dmdscript.script;
 import dmdscript.dobject;
@@ -524,7 +524,7 @@ struct Value
               // 16 digits, which is all the GCC library will round correctly.
 
               std.string.sformat(buffer, "%.16g\0", number);
-              //std.c.stdio.sprintf(buffer.ptr, "%.16g", number);
+              //core.stdc.stdio.sprintf(buffer.ptr, "%.16g", number);
 
               // Trim leading spaces
               for(p = buffer.ptr; *p == ' '; p++)
@@ -561,7 +561,7 @@ struct Value
                       }
                   }
               }
-              str = p[0 .. std.c.string.strlen(p)].idup;
+              str = p[0 .. core.stdc.string.strlen(p)].idup;
           }
           //writefln("str = '%s'", str);
           return str; }
@@ -593,12 +593,14 @@ struct Value
 
     d_string toString(int radix)
     {
+        import std.conv : to;
+
         if(vtype == V_NUMBER)
         {
             assert(2 <= radix && radix <= 36);
             if(!isFinite(number))
                 return toString();
-            return number >= 0.0 ? std.conv.to!(d_string)(cast(long)number, radix) : "-"~std.conv.to!(d_string)(cast(long)-number,radix);
+            return number >= 0.0 ? to!(d_string)(cast(long)number, radix) : "-"~to!(d_string)(cast(long)-number,radix);
         }
         else
         {

--- a/engine/source/dmdscript/value.d
+++ b/engine/source/dmdscript/value.d
@@ -355,7 +355,7 @@ struct Value
           number = toNumber();
           if(isNaN(number))
               number = 0;
-          else if(number == 0 || std.math.isinf(number))
+          else if(number == 0 || std.math.isInfinity(number))
           {
           }
           else if(number > 0)
@@ -389,7 +389,7 @@ struct Value
           number = toNumber();
           if(isNaN(number))
               int32 = 0;
-          else if(number == 0 || std.math.isinf(number))
+          else if(number == 0 || std.math.isInfinity(number))
               int32 = 0;
           else
           {
@@ -428,7 +428,7 @@ struct Value
           number = toNumber();
           if(isNaN(number))
               uint32 = 0;
-          else if(number == 0 || std.math.isinf(number))
+          else if(number == 0 || std.math.isInfinity(number))
               uint32 = 0;
           else
           {
@@ -465,7 +465,7 @@ struct Value
           number = toNumber();
           if(isNaN(number))
               uint16 = 0;
-          else if(number == 0 || std.math.isinf(number))
+          else if(number == 0 || std.math.isInfinity(number))
               uint16 = 0;
           else
           {
@@ -505,7 +505,7 @@ struct Value
               str = TEXT_NaN;
           else if(number >= 0 && number <= 9 && number == cast(int)number)
               str = strs[cast(int)number];
-          else if(std.math.isinf(number))
+          else if(std.math.isInfinity(number))
           {
               if(number < 0)
                   str = TEXT_negInfinity;

--- a/textgen.d
+++ b/textgen.d
@@ -20,8 +20,8 @@
 // Generates:
 //	text.d
 
-import std.c.stdio;
-import std.c.stdlib;
+import core.stdc.stdio;
+import core.stdc.stdlib;
 //import std.stdio;
 import std.string;
 


### PR DESCRIPTION
Fixes compile errors and warnings. This also makes a semantic change in the handling of variadic arguments for the various error functions and uses template based variadics together with `formattedWrite` instead of the old `doFormat` with argv/argc style API that doesn't exist anymore.

Would be great to also have a new "v2.0.4" tag once the fixes are merged, so that it will be usable through the DUB eco system again.