### PR TITLE
Adjust the code base for 64-bit systems. Fixes #7.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,7 @@
 ; Simple build script that just calls dub for each sub-package
 set BUILD=release
-dub build --arch=x86 --build=%BUILD% dmdscript:engine
-dub build --arch=x86 --build=%BUILD% dmdscript:ds
-dub build --arch=x86 --build=%BUILD% dmdscript:ds-ext
+dub build --build=%BUILD% dmdscript:engine
+dub build --build=%BUILD% dmdscript:ds
+dub build --build=%BUILD% dmdscript:ds-ext
 copy ds\dmdscript_ds.exe dmdscript.exe
 copy ds-ext\dmdscript_ds-ext.exe dmdscript-ext.exe

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 BUILD=release # debug
 for t in dmdscript:engine dmdscript:ds dmdscript:ds-ext
 do
-    dub build --arch=x86 --build=$BUILD $t || exit 1
+    dub build --build=$BUILD $t || exit 1
 done
 # copy 2 sample binaries to the root folder
 cp ds/dmdscript_ds ./dmdscript

--- a/engine/source/dmdscript/lexer.d
+++ b/engine/source/dmdscript/lexer.d
@@ -358,11 +358,11 @@ class Lexer
 
         if(!errinfo.message)
         {
-            uint len;
+            size_t len;
 
             errinfo.message = buf;
             errinfo.linnum = linnum;
-            errinfo.charpos = p - slinestart;
+            errinfo.charpos = cast(uint)(p - slinestart);
 
             len = slineend - slinestart;
             errinfo.srcline = slinestart[0 .. len];
@@ -391,7 +391,7 @@ class Lexer
         immutable(char) * slineend;
         immutable(char) * s;
         uint linnum = 1;
-        uint len;
+        size_t len;
 
         if(!src)
             return null;

--- a/engine/source/dmdscript/opcodes.d
+++ b/engine/source/dmdscript/opcodes.d
@@ -116,7 +116,7 @@ class Finally : Dobject
 
 Value* scope_get(Dobject[] scopex, Identifier* id, Dobject *pthis)
 {
-    uint d;
+    size_t d;
     Dobject o;
     Value* v;
 
@@ -146,7 +146,7 @@ Value* scope_get(Dobject[] scopex, Identifier* id, Dobject *pthis)
 
 Value* scope_get_lambda(Dobject[] scopex, Identifier* id, Dobject *pthis)
 {
-    uint d;
+    size_t d;
     Dobject o;
     Value* v;
 
@@ -179,7 +179,7 @@ Value* scope_get_lambda(Dobject[] scopex, Identifier* id, Dobject *pthis)
 
 Value* scope_get(Dobject[] scopex, Identifier* id)
 {
-    uint d;
+    size_t d;
     Dobject o;
     Value* v;
 
@@ -214,7 +214,7 @@ Value* scope_get(Dobject[] scopex, Identifier* id)
 
 Dobject scope_tos(Dobject[] scopex)
 {
-    uint d;
+    size_t d;
     Dobject o;
 
     for(d = scopex.length; d; )
@@ -237,7 +237,7 @@ void PutValue(CallContext *cc, d_string s, Value* a)
     // If we find it, put its value.
     // If we don't find it, put it into the global object
 
-    uint d;
+    size_t d;
     uint hash;
     Value* v;
     Dobject o;
@@ -281,7 +281,7 @@ void PutValue(CallContext *cc, Identifier* id, Value* a)
     // If we find it, put its value.
     // If we don't find it, put it into the global object
 
-    uint d;
+    size_t d;
     Value* v;
     Dobject o;
     //a.checkReference();
@@ -336,6 +336,11 @@ const uint INDEX_FACTOR = 16;   // or 1
 
 struct IR
 {
+    import core.stdc.stdint : uintptr_t;
+    alias Op = uintptr_t;
+
+    static assert(IR.sizeof == Op.sizeof);
+
     union
     {
         struct
@@ -343,19 +348,32 @@ struct IR
             version(LittleEndian)
             {
                 ubyte opcode;
-                ubyte padding;
-                ushort linnum;
+                static if (Op.sizeof == uint.sizeof) {
+                    ubyte padding;
+                    ushort linnum;
+                } else {
+                    ubyte[3] padding;
+                    uint linnum;
+                }
             }
             else
             {
-                ushort linnum;
-                ubyte padding;
-                ubyte opcode;
+                static if (Op.sizeof == uint.sizeof) {
+                    ushort linnum;
+                    ubyte padding;
+                    ubyte opcode;
+                } else {
+                    uint linnum;
+                    ubyte[3] padding;
+                    ubyte opcode;
+                }
             }
         }
                     IR* code;
         Value*      value;
-        uint        index;      // index into local variable table
+        // NOTE: this must be a uintptr_t, because it is frequently used to read
+        // the operand bits for a pointer value when generating the IR
+        uintptr_t        index;      // index into local variable table
         uint        hash;       // cached hash value
         int         offset;
         Identifier* id;
@@ -553,7 +571,7 @@ struct IR
         }
         scopex = cc.scopex;
         //printf("call: scope = %p, length = %d\n", scopex.ptr, scopex.length);
-        dimsave = scopex.length;
+        dimsave = cast(uint)scopex.length;
         //if (logflag)
         //    writef("IR.call(othis = %p, code = %p, locals = %p)\n",othis,code,locals);
 
@@ -588,7 +606,7 @@ struct IR
                 {
                     writef("Scopex len: %d ",scopex.length);
                     writef("%2d:", code - codestart);
-                    print(code - codestart, code);
+                    print(cast(uint)(code - codestart), code);
                     writeln();
                 }
 
@@ -901,7 +919,7 @@ struct IR
 
                 case IRnumber:              // a = number
                     GETa(code).putVnumber(*cast(d_number *)(code + 2));
-                    code += 4;
+                    code += 2 + d_number.sizeof/Op.sizeof;
                     break;
 
                 case IRboolean:             // a = boolean
@@ -1685,7 +1703,7 @@ struct IR
                     if(!res)
                         code += (code + 1).offset;
                     else
-                        code += 5;
+                        code += 3 + d_number.sizeof/Op.sizeof;
                     break;
 
                 case IRjlec:        // if (b <= constant) goto c
@@ -1694,7 +1712,7 @@ struct IR
                     if(!res)
                         code += (code + 1).offset;
                     else
-                        code += 5;
+                        code += 3 + d_number.sizeof/Op.sizeof;
                     break;
 
                 case IRiter:                // a = iter(b)
@@ -1997,7 +2015,7 @@ struct IR
                     break;
                 case IRtrycatch:
                     SCOPECACHE_CLEAR();
-                    offset = (code - codestart) + (code + 1).offset;
+                    offset = cast(uint)(code - codestart) + (code + 1).offset;
                     s = (code + 2).id.value.string;
                     ca = new Catch(offset, s);
                     scopex ~= ca;
@@ -2016,7 +2034,7 @@ struct IR
                 case IRassert:
                 {
                     ErrInfo errinfo;
-                    errinfo.linnum = (code + 1).index;
+                    errinfo.linnum = cast(uint)(code + 1).index;
                     version(all)  // Not supported under some com servers
                     {
                         a = Dobject.RuntimeError(&errinfo, errmsgtbl[ERR_ASSERT], (code + 1).index);
@@ -2573,7 +2591,7 @@ struct IR
             break;
 
         case IRnumber:              // a = number
-            sz = 4;
+            sz = 2 + d_number.sizeof/Op.sizeof;
             break;
 
         case IRboolean:             // a = boolean
@@ -2663,7 +2681,7 @@ struct IR
 
         case IRjltc:                // if (b < constant) goto t
         case IRjlec:                // if (b <= constant) goto t
-            sz = 5;
+            sz = 3 + d_number.sizeof/Op.sizeof;
             break;
 
         case IRjt:                  // if (b) goto t
@@ -2755,7 +2773,7 @@ struct IR
         {
             //writef("%2d(%d):", code - codestart, code.linnum);
             writef("%2d:", code - codestart);
-            print(code - codestart, code);
+            print(cast(uint)(code - codestart), code);
             if(code.opcode == IRend)
                 return;
             code += size(code.opcode);

--- a/engine/source/dmdscript/opcodes.d
+++ b/engine/source/dmdscript/opcodes.d
@@ -332,7 +332,7 @@ Value* cannotConvert(Value* b, int linnum)
     return b;
 }
 
-const uint INDEX_FACTOR = 16;   // or 1
+const uint INDEX_FACTOR = Value.sizeof;   // or 1
 
 struct IR
 {
@@ -513,23 +513,23 @@ struct IR
             // Eliminate the scale factor of Value.sizeof by computing it at compile time
             Value* GETa(IR* code)
             {
-                return cast(Value*)(cast(void*)locals + (code + 1).index * (16 / INDEX_FACTOR));
+                return cast(Value*)(cast(void*)locals + (code + 1).index * (Value.sizeof / INDEX_FACTOR));
             }
             Value* GETb(IR* code)
             {
-                return cast(Value*)(cast(void*)locals + (code + 2).index * (16 / INDEX_FACTOR));
+                return cast(Value*)(cast(void*)locals + (code + 2).index * (Value.sizeof / INDEX_FACTOR));
             }
             Value* GETc(IR* code)
             {
-                return cast(Value*)(cast(void*)locals + (code + 3).index * (16 / INDEX_FACTOR));
+                return cast(Value*)(cast(void*)locals + (code + 3).index * (Value.sizeof / INDEX_FACTOR));
             }
             Value* GETd(IR* code)
             {
-                return cast(Value*)(cast(void*)locals + (code + 4).index * (16 / INDEX_FACTOR));
+                return cast(Value*)(cast(void*)locals + (code + 4).index * (Value.sizeof / INDEX_FACTOR));
             }
             Value* GETe(IR* code)
             {
-                return cast(Value*)(cast(void*)locals + (code + 5).index * (16 / INDEX_FACTOR));
+                return cast(Value*)(cast(void*)locals + (code + 5).index * (Value.sizeof / INDEX_FACTOR));
             }
         }
         else
@@ -2055,6 +2055,7 @@ struct IR
              }
             catch(ErrorValue err)
             {
+                import std.stdio; writefln("ERROR: %s", err.toString());
                 v = unwindStack(&err.value);
                 if(v)//v is exception that was not caught
                     return v;

--- a/engine/source/dmdscript/outbuffer.d
+++ b/engine/source/dmdscript/outbuffer.d
@@ -266,7 +266,7 @@ class OutBuffer
         psize = buffer.length;
         for (;;)
         {
-            version(Win32)
+            version(Windows)
             {
                 count = _vsnprintf(p,psize,f,args);
                 if (count != -1)

--- a/engine/source/dmdscript/statement.d
+++ b/engine/source/dmdscript/statement.d
@@ -400,7 +400,7 @@ class BlockStatement : Statement
 
     override TopStatement ImpliedReturn()
     {
-        uint i = statements.length;
+        size_t i = statements.length;
 
         if(i)
         {
@@ -1080,7 +1080,7 @@ class ForStatement : Statement
                 if(be.e2.op == TOKreal && !isNaN(re.value))
                 {
                     u2 = irs.getIP();
-                    irs.gen(loc, (condition.op == TOKless) ? IRjltc : IRjlec, 4, 0, b, re.value);
+                    irs.genX(loc, (condition.op == TOKless) ? IRjltc : IRjlec, 0, b, re.value);
                 }
                 else
                 {
@@ -1250,7 +1250,7 @@ class ForInStatement : Statement
         if(opoff == 2)
             irs.gen3(loc, IRnextscope, 0, property.index, iter);
         else
-            irs.gen(loc, IRnext + opoff, 4, 0, base, property.index, iter);
+            irs.genX(loc, IRnext + opoff, 0, base, property.index, iter);
         bdy.toIR(irs);
         irs.gen1(loc, IRjmp, continueIP - irs.getIP());
         irs.patchJmp(continueIP, irs.getIP());
@@ -1419,7 +1419,7 @@ class ContinueStatement : Statement
             irs.pops(w.npops);
         }
         irs.addFixup(irs.getIP());
-        irs.gen1(loc, IRjmp, cast(uint)cast(void*)this);
+        irs.gen1(loc, IRjmp, cast(IRstate.Op)cast(void*)this);
     }
 
     override uint getTarget()
@@ -1494,7 +1494,7 @@ class BreakStatement : Statement
         }
 
         irs.addFixup(irs.getIP());
-        irs.gen1(loc, IRjmp, cast(uint)cast(void*)this);
+        irs.gen1(loc, IRjmp, cast(IRstate.Op)cast(void*)this);
     }
 
     override uint getTarget()
@@ -1554,7 +1554,7 @@ class GotoStatement : Statement
         }
 
         irs.addFixup(irs.getIP());
-        irs.gen1(loc, IRjmp, cast(uint)cast(void*)this);
+        irs.gen1(loc, IRjmp, cast(IRstate.Op)cast(void*)this);
     }
 
     override uint getTarget()
@@ -1806,7 +1806,7 @@ class TryStatement : ScopeStatement
             if(catchbdy)
             {
                 c = irs.getIP();
-                irs.gen2(loc, IRtrycatch, 0, cast(uint)Identifier.build(catchident.toString()));
+                irs.gen2(loc, IRtrycatch, 0, cast(IRstate.Op)Identifier.build(catchident.toString()));
                 bdy.toIR(irs);
                 irs.gen0(loc, IRpop);           // remove catch clause
                 irs.gen0(loc, IRpop);           // call finalbdy
@@ -1843,7 +1843,7 @@ class TryStatement : ScopeStatement
         else // catchbdy only
         {
             c = irs.getIP();
-            irs.gen2(loc, IRtrycatch, 0, cast(uint)Identifier.build(catchident.toString()));
+            irs.gen2(loc, IRtrycatch, 0, cast(IRstate.Op)Identifier.build(catchident.toString()));
             bdy.toIR(irs);
             irs.gen0(loc, IRpop);
             e = irs.getIP();

--- a/engine/source/dmdscript/value.d
+++ b/engine/source/dmdscript/value.d
@@ -693,14 +693,14 @@ struct Value
 
     static int stringcmp(d_string s1, d_string s2)
     {
-        int c = s1.length - s2.length;
+        sizediff_t c = s1.length - s2.length;
         if(c == 0)
         {
             if(s1.ptr == s2.ptr)
                 return 0;
             c = memcmp(s1.ptr, s2.ptr, s1.length);
         }
-        return c;
+        return cast(int)c;
     }
 
     int opCmp(const (Value)v) const
@@ -741,14 +741,14 @@ struct Value
             if(v.vtype == V_STRING)
             {
                 //writefln("'%s'.compareTo('%s')", string, v.string);
-                int len = string.length - v.string.length;
+                sizediff_t len = string.length - v.string.length;
                 if(len == 0)
                 {
                     if(string.ptr == v.string.ptr)
                         return 0;
                     len = memcmp(string.ptr, v.string.ptr, string.length);
                 }
-                return len;
+                return cast(int)len;
             }
             else if(v.vtype == V_NUMBER)
             {
@@ -904,7 +904,7 @@ struct Value
                 break;
 
             default:
-            { uint len = s.length;
+            { size_t len = s.length;
               ubyte *str = cast(ubyte*)s.ptr;
 
               hash = 0;


### PR DESCRIPTION
This changes the size of IR from 4 bytes to 8 bytes for 64-bit builds. The critical places during IR code generation have been verified to handle pointer and double values correctly, but since there is no type checking going on in this part of the code and thus relies fully on testing.