### PR TITLE
Remove the global Program.program.

### DIFF
--- a/engine/source/dmdscript/darguments.d
+++ b/engine/source/dmdscript/darguments.d
@@ -41,26 +41,26 @@ class Darguments : Dobject
         return true;
     }
 
-    this(Dobject caller, Dobject callee, Dobject actobj,
+    this(CallContext* cc, Dobject caller, Dobject callee, Dobject actobj,
          Identifier *[] parameters, Value[] arglist)
 
     {
-        super(Dobject.getPrototype());
+        super(cc, Dobject.getPrototype());
 
         this.actobj = actobj;
         this.parameters = parameters;
 
         if(caller)
-            Put(TEXT_caller, caller, DontEnum);
+            Put(cc, TEXT_caller, caller, DontEnum);
         else
-            Put(TEXT_caller, &vnull, DontEnum);
+            Put(cc, TEXT_caller, &vnull, DontEnum);
 
-        Put(TEXT_callee, callee, DontEnum);
-        Put(TEXT_length, arglist.length, DontEnum);
+        Put(cc, TEXT_callee, callee, DontEnum);
+        Put(cc, TEXT_length, arglist.length, DontEnum);
 
         for(uint a = 0; a < arglist.length; a++)
         {
-            Put(a, &arglist[a], DontEnum);
+            Put(cc, a, &arglist[a], DontEnum);
         }
     }
 
@@ -87,60 +87,60 @@ class Darguments : Dobject
                : Dobject.Get(index, vindex);
     }
 
-    override Value* Put(string PropertyName, Value* value, uint attributes)
+    override Value* Put(CallContext* cc, string PropertyName, Value* value, uint attributes)
     {
         d_uint32 index;
 
         if(StringToIndex(PropertyName, index) && index < parameters.length)
-            return actobj.Put(PropertyName, value, attributes);
+            return actobj.Put(cc, PropertyName, value, attributes);
         else
-            return Dobject.Put(PropertyName, value, attributes);
+            return Dobject.Put(cc, PropertyName, value, attributes);
     }
 
-    override Value* Put(Identifier* key, Value* value, uint attributes)
+    override Value* Put(CallContext* cc, Identifier* key, Value* value, uint attributes)
     {
         d_uint32 index;
 
         if(StringToIndex(key.value.string, index) && index < parameters.length)
-            return actobj.Put(key, value, attributes);
+            return actobj.Put(cc, key, value, attributes);
         else
-            return Dobject.Put(key, value, attributes);
+            return Dobject.Put(cc, key, value, attributes);
     }
 
-    override Value* Put(string PropertyName, Dobject o, uint attributes)
+    override Value* Put(CallContext* cc, string PropertyName, Dobject o, uint attributes)
     {
         d_uint32 index;
 
         if(StringToIndex(PropertyName, index) && index < parameters.length)
-            return actobj.Put(PropertyName, o, attributes);
+            return actobj.Put(cc, PropertyName, o, attributes);
         else
-            return Dobject.Put(PropertyName, o, attributes);
+            return Dobject.Put(cc, PropertyName, o, attributes);
     }
 
-    override Value* Put(string PropertyName, d_number n, uint attributes)
+    override Value* Put(CallContext* cc, string PropertyName, d_number n, uint attributes)
     {
         d_uint32 index;
 
         if(StringToIndex(PropertyName, index) && index < parameters.length)
-            return actobj.Put(PropertyName, n, attributes);
+            return actobj.Put(cc, PropertyName, n, attributes);
         else
-            return Dobject.Put(PropertyName, n, attributes);
+            return Dobject.Put(cc, PropertyName, n, attributes);
     }
 
-    override Value* Put(d_uint32 index, Value* vindex, Value* value, uint attributes)
+    override Value* Put(CallContext* cc, d_uint32 index, Value* vindex, Value* value, uint attributes)
     {
         if(index < parameters.length)
-            return actobj.Put(index, vindex, value, attributes);
+            return actobj.Put(cc, index, vindex, value, attributes);
         else
-            return Dobject.Put(index, vindex, value, attributes);
+            return Dobject.Put(cc, index, vindex, value, attributes);
     }
 
-    override Value* Put(d_uint32 index, Value* value, uint attributes)
+    override Value* Put(CallContext* cc, d_uint32 index, Value* value, uint attributes)
     {
         if(index < parameters.length)
-            return actobj.Put(index, value, attributes);
+            return actobj.Put(cc, index, value, attributes);
         else
-            return Dobject.Put(index, value, attributes);
+            return Dobject.Put(cc, index, value, attributes);
     }
 
     override int CanPut(d_string PropertyName)

--- a/engine/source/dmdscript/darray.d
+++ b/engine/source/dmdscript/darray.d
@@ -42,9 +42,9 @@ import dmdscript.program;
 
 class DarrayConstructor : Dfunction
 {
-    this()
+    this(CallContext* cc)
     {
-        super(1, Dfunction_prototype);
+        super(cc, 1, Dfunction_prototype);
         name = "Array";
     }
 
@@ -53,7 +53,7 @@ class DarrayConstructor : Dfunction
         // ECMA 15.4.2
         Darray a;
 
-        a = new Darray();
+        a = new Darray(cc);
         if(arglist.length == 0)
         {
             a.ulength = 0;
@@ -67,13 +67,13 @@ class DarrayConstructor : Dfunction
             {
                 d_uint32 len;
 
-                len = v.toUint32();
+                len = v.toUint32(cc);
                 if(cast(double)len != v.number)
                 {
                     ErrInfo errinfo;
 
                     ret.putVundefined();
-                    return RangeError(&errinfo, ERR_ARRAY_LEN_OUT_OF_BOUNDS, v.number);
+                    return RangeError(&errinfo, cc, ERR_ARRAY_LEN_OUT_OF_BOUNDS, v.number);
                 }
                 else
                 {
@@ -95,7 +95,7 @@ class DarrayConstructor : Dfunction
             {
                 a.ulength = 1;
                 a.length.number = 1;
-                a.Put(cast(d_uint32)0, v, 0);
+                a.Put(cc, cast(d_uint32)0, v, 0);
             }
         }
         else
@@ -112,7 +112,7 @@ class DarrayConstructor : Dfunction
             a.length.number = arglist.length;
             for(uint k = 0; k < arglist.length; k++)
             {
-                a.Put(k, &arglist[k], 0);
+                a.Put(cc, k, &arglist[k], 0);
             }
         }
         Value.copy(ret, &a.value);
@@ -133,7 +133,7 @@ class DarrayConstructor : Dfunction
 void *Darray_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
     //writef("Darray_prototype_toString()\n");
-    array_join(othis, ret, null);
+    array_join(othis, cc, ret, null);
     return null;
 }
 
@@ -154,11 +154,11 @@ void *Darray_prototype_toLocaleString(Dobject pthis, CallContext *cc, Dobject ot
     {
         ret.putVundefined();
         ErrInfo errinfo;
-        return Dobject.RuntimeError(&errinfo, ERR_TLS_NOT_TRANSFERRABLE);
+        return Dobject.RuntimeError(&errinfo, cc, ERR_TLS_NOT_TRANSFERRABLE);
     }
 
     v = othis.Get(TEXT_length);
-    len = v ? v.toUint32() : 0;
+    len = v ? v.toUint32(cc) : 0;
 
     Program prog = cc.prog;
     if(!prog.slist)
@@ -178,7 +178,7 @@ void *Darray_prototype_toLocaleString(Dobject pthis, CallContext *cc, Dobject ot
         {
             Dobject ot;
 
-            ot = v.toObject();
+            ot = v.toObject(cc);
             v = ot.Get(TEXT_toLocaleString);
             if(v && !v.isPrimitive())   // if it's an Object
             {
@@ -191,7 +191,7 @@ void *Darray_prototype_toLocaleString(Dobject pthis, CallContext *cc, Dobject ot
                 a = o.Call(cc, ot, &rt, null);
                 if(a)                   // if exception was thrown
                     return a;
-                r ~= rt.toString();
+                r ~= rt.toString(cc);
             }
         }
     }
@@ -212,7 +212,7 @@ void *Darray_prototype_concat(Dobject pthis, CallContext *cc, Dobject othis, Val
     d_uint32 n;
     d_uint32 a;
 
-    A = new Darray();
+    A = new Darray(cc);
     n = 0;
     v = &othis.value;
     for(a = 0;; a++)
@@ -227,13 +227,13 @@ void *Darray_prototype_concat(Dobject pthis, CallContext *cc, Dobject othis, Val
             {
                 v = E.Get(k);
                 if(v)
-                    A.Put(n, v, 0);
+                    A.Put(cc, n, v, 0);
                 n++;
             }
         }
         else
         {
-            A.Put(n, v, 0);
+            A.Put(cc, n, v, 0);
             n++;
         }
         if(a == arglist.length)
@@ -241,7 +241,7 @@ void *Darray_prototype_concat(Dobject pthis, CallContext *cc, Dobject othis, Val
         v = &arglist[a];
     }
 
-    A.Put(TEXT_length, n,  DontEnum);
+    A.Put(cc, TEXT_length, n,  DontEnum);
     Value.copy(ret, &A.value);
     return null;
 }
@@ -250,11 +250,11 @@ void *Darray_prototype_concat(Dobject pthis, CallContext *cc, Dobject othis, Val
 
 void *Darray_prototype_join(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    array_join(othis, ret, arglist);
+    array_join(othis, cc, ret, arglist);
     return null;
 }
 
-void array_join(Dobject othis, Value* ret, Value[] arglist)
+void array_join(Dobject othis, CallContext* cc, Value* ret, Value[] arglist)
 {
     // ECMA 15.4.4.3
     d_string separator;
@@ -265,11 +265,11 @@ void array_join(Dobject othis, Value* ret, Value[] arglist)
 
     //writef("array_join(othis = %p)\n", othis);
     v = othis.Get(TEXT_length);
-    len = v ? v.toUint32() : 0;
+    len = v ? v.toUint32(cc) : 0;
     if(arglist.length == 0 || arglist[0].isUndefined())
         separator = TEXT_comma;
     else
-        separator = arglist[0].toString();
+        separator = arglist[0].toString(cc);
 
     for(k = 0; k != len; k++)
     {
@@ -277,7 +277,7 @@ void array_join(Dobject othis, Value* ret, Value[] arglist)
             r ~= separator;
         v = othis.Get(k);
         if(v && !v.isUndefinedOrNull())
-            r ~= v.toString();
+            r ~= v.toString(cc);
     }
 
     ret.putVstring(r);
@@ -294,7 +294,7 @@ void *Darray_prototype_toSource(Dobject pthis, CallContext *cc, Dobject othis, V
     Value* v;
 
     v = othis.Get(TEXT_length);
-    len = v ? v.toUint32() : 0;
+    len = v ? v.toUint32(cc) : 0;
     separator = ",";
 
     r = "[".idup;
@@ -304,7 +304,7 @@ void *Darray_prototype_toSource(Dobject pthis, CallContext *cc, Dobject othis, V
             r ~= separator;
         v = othis.Get(k);
         if(v && !v.isUndefinedOrNull())
-            r ~= v.toSource();
+            r ~= v.toSource(cc);
     }
     r ~= "]";
 
@@ -325,10 +325,10 @@ void *Darray_prototype_pop(Dobject pthis, CallContext *cc, Dobject othis, Value 
     v = othis.Get(TEXT_length);
     if(!v)
         v = &vundefined;
-    u = v.toUint32();
+    u = v.toUint32(cc);
     if(u == 0)
     {
-        othis.Put(TEXT_length, 0.0,  DontEnum);
+        othis.Put(cc, TEXT_length, 0.0,  DontEnum);
         ret.putVundefined();
     }
     else
@@ -338,7 +338,7 @@ void *Darray_prototype_pop(Dobject pthis, CallContext *cc, Dobject othis, Value 
             v = &vundefined;
         Value.copy(ret, v);
         othis.Delete(u - 1);
-        othis.Put(TEXT_length, u - 1,  DontEnum);
+        othis.Put(cc, TEXT_length, u - 1,  DontEnum);
     }
     return null;
 }
@@ -356,12 +356,12 @@ void *Darray_prototype_push(Dobject pthis, CallContext *cc, Dobject othis, Value
     v = othis.Get(TEXT_length);
     if(!v)
         v = &vundefined;
-    u = v.toUint32();
+    u = v.toUint32(cc);
     for(a = 0; a < arglist.length; a++)
     {
-        othis.Put(u + a, &arglist[a], 0);
+        othis.Put(cc, u + a, &arglist[a], 0);
     }
-    othis.Put(TEXT_length, u + a,  DontEnum);
+    othis.Put(cc, TEXT_length, u + a,  DontEnum);
     ret.putVnumber(u + a);
     return null;
 }
@@ -381,7 +381,7 @@ void *Darray_prototype_reverse(Dobject pthis, CallContext *cc, Dobject othis, Va
     Value tmp;
 
     v = othis.Get(TEXT_length);
-    len = v ? v.toUint32() : 0;
+    len = v ? v.toUint32(cc) : 0;
     pivot = len / 2;
     for(a = 0; a != pivot; a++)
     {
@@ -392,12 +392,12 @@ void *Darray_prototype_reverse(Dobject pthis, CallContext *cc, Dobject othis, Va
             Value.copy(&tmp, va);
         vb = othis.Get(b);
         if(vb)
-            othis.Put(a, vb, 0);
+            othis.Put(cc, a, vb, 0);
         else
             othis.Delete(a);
 
         if(va)
-            othis.Put(b, &tmp, 0);
+            othis.Put(cc, b, &tmp, 0);
         else
             othis.Delete(b);
     }
@@ -420,7 +420,7 @@ void *Darray_prototype_shift(Dobject pthis, CallContext *cc, Dobject othis, Valu
     v = othis.Get(TEXT_length);
     if(!v)
         v = &vundefined;
-    len = v.toUint32();
+    len = v.toUint32(cc);
     
     if(len)
     {
@@ -431,7 +431,7 @@ void *Darray_prototype_shift(Dobject pthis, CallContext *cc, Dobject othis, Valu
             v = othis.Get(k);
             if(v)
             {
-                othis.Put(k - 1, v, 0);
+                othis.Put(cc, k - 1, v, 0);
             }
             else
             {
@@ -444,7 +444,7 @@ void *Darray_prototype_shift(Dobject pthis, CallContext *cc, Dobject othis, Valu
     else
         Value.copy(ret, &vundefined);
 
-    othis.Put(TEXT_length, len, DontEnum);
+    othis.Put(cc, TEXT_length, len, DontEnum);
     return null;
 }
 
@@ -465,7 +465,7 @@ void *Darray_prototype_slice(Dobject pthis, CallContext *cc, Dobject othis, Valu
     v = othis.Get(TEXT_length);
     if(!v)
         v = &vundefined;
-    len = v.toUint32();
+    len = v.toUint32(cc);
 
 version(SliceSpliceExtension){
     d_number start;
@@ -473,21 +473,21 @@ version(SliceSpliceExtension){
     switch(arglist.length)
     {
     case 0:
-        start = vundefined.toNumber();
+        start = vundefined.toNumber(cc);
         end = len;
         break;
 
     case 1:
-        start = arglist[0].toNumber();
+        start = arglist[0].toNumber(cc);
         end = len;
         break;
 
     default:
-        start = arglist[0].toNumber();
+        start = arglist[0].toNumber(cc);
 		if(arglist[1].isUndefined())
 			end = len;
 		else{
-			end = arglist[1].toNumber();
+			end = arglist[1].toNumber(cc);
 		}
         break;
     }
@@ -575,18 +575,18 @@ else{//Canonical ECMA all kinds of infinity maped to 0
             r8 = len;
     }
 }
-    A = new Darray();
+    A = new Darray(cc);
     for(n = 0; k < r8; k++)
     {
         v = othis.Get(k);
         if(v)
         {
-            A.Put(n, v, 0);
+            A.Put(cc, n, v, 0);
         }
         n++;
     }
 
-    A.Put(TEXT_length, n, DontEnum);
+    A.Put(cc, TEXT_length, n, DontEnum);
     Value.copy(ret, &A.value);
     return null;
 }
@@ -603,7 +603,7 @@ void *Darray_prototype_sort(Dobject pthis, CallContext *cc, Dobject othis, Value
 
     //writef("Array.prototype.sort()\n");
     v = othis.Get(TEXT_length);
-    len = v ? v.toUint32() : 0;
+    len = v ? v.toUint32(cc) : 0;
 
     // This is not optimal, as isArrayIndex is done at least twice
     // for every array member. Additionally, the qsort() by index
@@ -668,7 +668,7 @@ void *Darray_prototype_sort(Dobject pthis, CallContext *cc, Dobject othis, Value
     {
         d_uint32 index;
 
-        if(p.attributes == 0 && key.isArrayIndex(index))
+        if(p.attributes == 0 && key.isArrayIndex(cc, index))
         {
             pindices[nprops] = index;
             Value.copy(&pvalues[nprops], &p.value);
@@ -713,7 +713,7 @@ void *Darray_prototype_sort(Dobject pthis, CallContext *cc, Dobject othis, Value
                     Value.copy(&arglist[1], &vy);
                     ret.putVundefined();
                     comparefn.Call(cc, comparefn, &ret, arglist);
-                    n = ret.toNumber();
+                    n = ret.toNumber(cc);
                     if(n < 0)
                         cmp = -1;
                     else if(n > 0)
@@ -723,8 +723,8 @@ void *Darray_prototype_sort(Dobject pthis, CallContext *cc, Dobject othis, Value
                 }
                 else
                 {
-                    sx = vx.toString();
-                    sy = vy.toString();
+                    sx = vx.toString(cc);
+                    sy = vy.toString(cc);
                     cmp = std.string.cmp(sx, sy);
                     if(cmp < 0)
                         cmp = -1;
@@ -745,7 +745,7 @@ void *Darray_prototype_sort(Dobject pthis, CallContext *cc, Dobject othis, Value
     {
         d_uint32 index;
 
-        othis.Put(u, &pvalues[u], 0);
+        othis.Put(cc, u, &pvalues[u], 0);
         index = pindices[u];
         if(index >= nprops)
         {
@@ -778,7 +778,7 @@ void *Darray_prototype_splice(Dobject pthis, CallContext *cc, Dobject othis, Val
     v = othis.Get(TEXT_length);
     if(!v)
         v = &vundefined;
-    len = v.toUint32();
+    len = v.toUint32(cc);
     
 version(SliceSpliceExtension){
     d_number start;
@@ -787,18 +787,18 @@ version(SliceSpliceExtension){
     switch(arglist.length)
     {
     case 0:
-        start = vundefined.toNumber();
+        start = vundefined.toNumber(cc);
         deleteCount = 0;
         break;
 
     case 1:
-        start = arglist[0].toNumber();
-        deleteCount = vundefined.toNumber();
+        start = arglist[0].toNumber(cc);
+        deleteCount = vundefined.toNumber(cc);
         break;
 
     default:
-        start = arglist[0].toNumber();
-        deleteCount = arglist[1].toNumber();
+        start = arglist[0].toNumber(cc);
+        deleteCount = arglist[1].toNumber(cc);
 		//checked later
         break;
     }
@@ -853,7 +853,7 @@ version(SliceSpliceExtension){
         delcnt = len - startidx;
 }
 	
-    A = new Darray();
+    A = new Darray(cc);
 
     // If deleteCount is not specified, ECMA implies it should
     // be 0, while "JavaScript The Definitive Guide" says it should
@@ -867,10 +867,10 @@ version(SliceSpliceExtension){
     {
         v = othis.Get(startidx + k);
         if(v)
-            A.Put(k, v, 0);
+            A.Put(cc, k, v, 0);
     }
 
-    A.Put(TEXT_length, delcnt, DontEnum);
+    A.Put(cc, TEXT_length, delcnt, DontEnum);
     inscnt = (arglist.length > 2) ? cast(uint)arglist.length - 2 : 0;
     if(inscnt != delcnt)
     {
@@ -880,7 +880,7 @@ version(SliceSpliceExtension){
             {
                 v = othis.Get(k + delcnt);
                 if(v)
-                    othis.Put(k + inscnt, v, 0);
+                    othis.Put(cc, k + inscnt, v, 0);
                 else
                     othis.Delete(k + inscnt);
             }
@@ -894,7 +894,7 @@ version(SliceSpliceExtension){
             {
                 v = othis.Get(k + delcnt - 1);
                 if(v)
-                    othis.Put(k + inscnt - 1, v, 0);
+                    othis.Put(cc, k + inscnt - 1, v, 0);
                 else
                     othis.Delete(k + inscnt - 1);
             }
@@ -904,11 +904,11 @@ version(SliceSpliceExtension){
     for(a = 2; a < arglist.length; a++)
     {
         v = &arglist[a];
-        othis.Put(k, v, 0);
+        othis.Put(cc, k, v, 0);
         k++;
     }
 
-    othis.Put(TEXT_length, len - delcnt + inscnt,  DontEnum);
+    othis.Put(cc, TEXT_length, len - delcnt + inscnt,  DontEnum);
     Value.copy(ret, &A.value);
     return null;
 }
@@ -925,22 +925,22 @@ void *Darray_prototype_unshift(Dobject pthis, CallContext *cc, Dobject othis, Va
     v = othis.Get(TEXT_length);
     if(!v)
         v = &vundefined;
-    len = v.toUint32();
+    len = v.toUint32(cc);
 
     for(k = len; k>0; k--)
     {
         v = othis.Get(k - 1);
         if(v)
-            othis.Put(cast(uint)(k + arglist.length - 1), v, 0);
+            othis.Put(cc, cast(uint)(k + arglist.length - 1), v, 0);
         else
             othis.Delete(cast(uint)(k + arglist.length - 1));
     }
 
     for(k = 0; k < arglist.length; k++)
     {
-        othis.Put(k, &arglist[k], 0);
+        othis.Put(cc, k, &arglist[k], 0);
     }
-    othis.Put(TEXT_length, len + arglist.length,  DontEnum);
+    othis.Put(cc, TEXT_length, len + arglist.length,  DontEnum);
     ret.putVnumber(len + arglist.length);
     return null;
 }
@@ -949,12 +949,12 @@ void *Darray_prototype_unshift(Dobject pthis, CallContext *cc, Dobject othis, Va
 
 class DarrayPrototype : Darray
 {
-    this()
+    this(CallContext* cc)
     {
-        super(Dobject_prototype);
+        super(cc, Dobject_prototype);
         Dobject f = Dfunction_prototype;
 
-        Put(TEXT_constructor, Darray_constructor, DontEnum);
+        Put(cc, TEXT_constructor, Darray_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -973,7 +973,7 @@ class DarrayPrototype : Darray
             { TEXT_unshift, &Darray_prototype_unshift, 1 },
         ];
 
-        DnativeFunction.initialize(this, nfd, DontEnum);
+        DnativeFunction.initialize(this, cc, nfd, DontEnum);
     }
 }
 
@@ -985,28 +985,28 @@ class Darray : Dobject
     Value length;               // length property
     d_uint32 ulength;
 
-    this()
+    this(CallContext* cc)
     {
-        this(getPrototype());
+        this(cc, getPrototype());
     }
 
-    this(Dobject prototype)
+    this(CallContext* cc, Dobject prototype)
     {
-        super(prototype);
+        super(cc, prototype);
         length.putVnumber(0);
         ulength = 0;
         classname = TEXT_Array;
     }
 
-    override  Value* Put(Identifier* key, Value* value, uint attributes)
+    override  Value* Put(CallContext* cc, Identifier* key, Value* value, uint attributes)
     {
         Value* result = proptable.put(&key.value, key.value.hash, value, attributes);
         if(!result)
-            Put(key.value.string, value, attributes);
+            Put(cc, key.value.string, value, attributes);
         return null;
     }
 
-    override Value* Put(d_string name, Value* v, uint attributes)
+    override Value* Put(CallContext* cc, d_string name, Value* v, uint attributes)
     {
         d_uint32 i;
         uint c;
@@ -1018,12 +1018,12 @@ class Darray : Dobject
         {
             if(name == TEXT_length)
             {
-                i = v.toUint32();
-                if(i != v.toInteger())
+                i = v.toUint32(cc);
+                if(i != v.toInteger(cc))
                 {
                     ErrInfo errinfo;
 
-                    return Dobject.RangeError(&errinfo, ERR_LENGTH_INT);
+                    return Dobject.RangeError(&errinfo, cc, ERR_LENGTH_INT);
                 }
                 if(i < ulength)
                 {
@@ -1034,7 +1034,7 @@ class Darray : Dobject
                     {
                         d_uint32 j;
 
-                        j = key.toUint32();
+                        j = key.toUint32(cc);
                         if(j >= i)
                             todelete ~= j;
                     }
@@ -1080,28 +1080,28 @@ class Darray : Dobject
         return null;
     }
 
-    override Value* Put(d_string name, Dobject o, uint attributes)
+    override Value* Put(CallContext* cc, d_string name, Dobject o, uint attributes)
     {
-        return Put(name, &o.value, attributes);
+        return Put(cc, name, &o.value, attributes);
     }
 
-    override Value* Put(d_string PropertyName, d_number n, uint attributes)
+    override Value* Put(CallContext* cc, d_string PropertyName, d_number n, uint attributes)
     {
         Value v;
 
         v.putVnumber(n);
-        return Put(PropertyName, &v, attributes);
+        return Put(cc, PropertyName, &v, attributes);
     }
 
-    override Value* Put(d_string PropertyName, d_string string, uint attributes)
+    override Value* Put(CallContext* cc, d_string PropertyName, d_string string, uint attributes)
     {
         Value v;
 
         v.putVstring(string);
-        return Put(PropertyName, &v, attributes);
+        return Put(cc, PropertyName, &v, attributes);
     }
 
-    override Value* Put(d_uint32 index, Value* vindex, Value* value, uint attributes)
+    override Value* Put(CallContext* cc, d_uint32 index, Value* vindex, Value* value, uint attributes)
     {
         if(index >= ulength)
             ulength = index + 1;
@@ -1110,7 +1110,7 @@ class Darray : Dobject
         return null;
     }
 
-    override Value* Put(d_uint32 index, Value* value, uint attributes)
+    override Value* Put(CallContext* cc, d_uint32 index, Value* value, uint attributes)
     {
         if(index >= ulength)
         {
@@ -1122,7 +1122,7 @@ class Darray : Dobject
         return null;
     }
 
-    final Value* Put(d_uint32 index, d_string string, uint attributes)
+    final Value* Put(CallContext* cc, d_uint32 index, d_string string, uint attributes)
     {
         if(index >= ulength)
         {
@@ -1203,12 +1203,12 @@ class Darray : Dobject
         return Darray_prototype;
     }
 
-    static void initialize()
+    static void initialize(CallContext* cc)
     {
-        Darray_constructor = new DarrayConstructor();
-        Darray_prototype = new DarrayPrototype();
+        Darray_constructor = new DarrayConstructor(cc);
+        Darray_prototype = new DarrayPrototype(cc);
 
-        Darray_constructor.Put(TEXT_prototype, Darray_prototype, DontEnum |  ReadOnly);
+        Darray_constructor.Put(cc, TEXT_prototype, Darray_prototype, DontEnum |  ReadOnly);
     }
 }
 

--- a/engine/source/dmdscript/dboolean.d
+++ b/engine/source/dmdscript/dboolean.d
@@ -31,9 +31,9 @@ import dmdscript.dnative;
 
 class DbooleanConstructor : Dfunction
 {
-    this()
+    this(CallContext* cc)
     {
-        super(1, Dfunction_prototype);
+        super(cc, 1, Dfunction_prototype);
         name = "Boolean";
     }
 
@@ -43,8 +43,8 @@ class DbooleanConstructor : Dfunction
         d_boolean b;
         Dobject o;
 
-        b = (arglist.length) ? arglist[0].toBoolean() : false;
-        o = new Dboolean(b);
+        b = (arglist.length) ? arglist[0].toBoolean(cc) : false;
+        o = new Dboolean(cc, b);
         ret.putVobject(o);
         return null;
     }
@@ -54,7 +54,7 @@ class DbooleanConstructor : Dfunction
         // ECMA 15.6.1
         d_boolean b;
 
-        b = (arglist.length) ? arglist[0].toBoolean() : false;
+        b = (arglist.length) ? arglist[0].toBoolean(cc) : false;
         ret.putVboolean(b);
         return null;
     }
@@ -71,7 +71,7 @@ void* Dboolean_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis,
         ErrInfo errinfo;
 
         ret.putVundefined();
-        return Dobject.RuntimeError(&errinfo, errmsgtbl[ERR_FUNCTION_WANTS_BOOL],
+        return Dobject.RuntimeError(&errinfo, cc, errmsgtbl[ERR_FUNCTION_WANTS_BOOL],
                                     TEXT_toString,
                                     othis.classname);
     }
@@ -80,7 +80,7 @@ void* Dboolean_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis,
         Value *v;
 
         v = &(cast(Dboolean)othis).value;
-        ret.putVstring(v.toString());
+        ret.putVstring(v.toString(cc));
     }
     return null;
 }
@@ -98,7 +98,7 @@ void* Dboolean_prototype_valueOf(Dobject pthis, CallContext *cc, Dobject othis, 
         ErrInfo errinfo;
 
         ret.putVundefined();
-        return Dobject.RuntimeError(&errinfo, errmsgtbl[ERR_FUNCTION_WANTS_BOOL],
+        return Dobject.RuntimeError(&errinfo, cc, errmsgtbl[ERR_FUNCTION_WANTS_BOOL],
                                     TEXT_valueOf,
                                     othis.classname);
     }
@@ -116,12 +116,12 @@ void* Dboolean_prototype_valueOf(Dobject pthis, CallContext *cc, Dobject othis, 
 
 class DbooleanPrototype : Dboolean
 {
-    this()
+    this(CallContext* cc)
     {
-        super(Dobject_prototype);
+        super(cc, Dobject_prototype);
         //Dobject f = Dfunction_prototype;
 
-        Put(TEXT_constructor, Dboolean_constructor, DontEnum);
+        Put(cc, TEXT_constructor, Dboolean_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -129,7 +129,7 @@ class DbooleanPrototype : Dboolean
             { TEXT_valueOf, &Dboolean_prototype_valueOf, 0 },
         ];
 
-        DnativeFunction.initialize(this, nfd, DontEnum);
+        DnativeFunction.initialize(this, cc, nfd, DontEnum);
     }
 }
 
@@ -138,16 +138,16 @@ class DbooleanPrototype : Dboolean
 
 class Dboolean : Dobject
 {
-    this(d_boolean b)
+    this(CallContext* cc, d_boolean b)
     {
-        super(Dboolean.getPrototype());
+        super(cc, Dboolean.getPrototype());
         value.putVboolean(b);
         classname = TEXT_Boolean;
     }
 
-    this(Dobject prototype)
+    this(CallContext* cc, Dobject prototype)
     {
-        super(prototype);
+        super(cc, prototype);
         value.putVboolean(false);
         classname = TEXT_Boolean;
     }
@@ -162,12 +162,12 @@ class Dboolean : Dobject
         return Dboolean_prototype;
     }
 
-    static void initialize()
+    static void initialize(CallContext* cc)
     {
-        Dboolean_constructor = new DbooleanConstructor();
-        Dboolean_prototype = new DbooleanPrototype();
+        Dboolean_constructor = new DbooleanConstructor(cc);
+        Dboolean_prototype = new DbooleanPrototype(cc);
 
-        Dboolean_constructor.Put(TEXT_prototype, Dboolean_prototype, DontEnum | DontDelete | ReadOnly);
+        Dboolean_constructor.Put(cc, TEXT_prototype, Dboolean_prototype, DontEnum | DontDelete | ReadOnly);
     }
 }
 

--- a/engine/source/dmdscript/ddate.d
+++ b/engine/source/dmdscript/ddate.d
@@ -119,7 +119,7 @@ void* Ddate_parse(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Val
         n = d_time_nan;
     else
     {
-        s = arglist[0].toString();
+        s = arglist[0].toString(cc);
         n = parseDateString(cc, s);
     }
 
@@ -148,26 +148,26 @@ void* Ddate_UTC(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     {
     default:
     case 7:
-        ms = arglist[6].toDtime();
+        ms = arglist[6].toDtime(cc);
         goto case;
     case 6:
-        seconds = arglist[5].toDtime();
+        seconds = arglist[5].toDtime(cc);
         goto case;
     case 5:
-        minutes = arglist[4].toDtime();
+        minutes = arglist[4].toDtime(cc);
         goto case;
     case 4:
-        hours = arglist[3].toDtime();
+        hours = arglist[3].toDtime(cc);
         time = makeTime(hours, minutes, seconds, ms);
         goto case;
     case 3:
-        date = arglist[2].toDtime();
+        date = arglist[2].toDtime(cc);
         goto case;
     case 2:
-        month = arglist[1].toDtime();
+        month = arglist[1].toDtime(cc);
         goto case;
     case 1:
-        year = arglist[0].toDtime();
+        year = arglist[0].toDtime(cc);
 
         if(year != d_time_nan && year >= 0 && year <= 99)
             year += 1900;
@@ -187,9 +187,9 @@ void* Ddate_UTC(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
 
 class DdateConstructor : Dfunction
 {
-    this()
+    this(CallContext* cc)
     {
-        super(7, Dfunction_prototype);
+        super(cc, 7, Dfunction_prototype);
         name = "Date";
 
         static enum NativeFunctionData[] nfd =
@@ -198,7 +198,7 @@ class DdateConstructor : Dfunction
             { TEXT_UTC, &Ddate_UTC, 7 },
         ];
 
-        DnativeFunction.initialize(this, nfd, DontEnum);
+        DnativeFunction.initialize(this, cc, nfd, DontEnum);
     }
 
     override void *Construct(CallContext *cc, Value *ret, Value[] arglist)
@@ -230,28 +230,28 @@ class DdateConstructor : Dfunction
         {
         default:
         case 7:
-            ms = arglist[6].toDtime();
+            ms = arglist[6].toDtime(cc);
             mixin (breakOnNan("ms"));
             goto case;
         case 6:
-            seconds = arglist[5].toDtime();
+            seconds = arglist[5].toDtime(cc);
             mixin (breakOnNan("seconds"));
             goto case;
         case 5:
-            minutes = arglist[4].toDtime();
+            minutes = arglist[4].toDtime(cc);
             mixin (breakOnNan("minutes"));
             goto case;
         case 4:
-            hours = arglist[3].toDtime();
+            hours = arglist[3].toDtime(cc);
             mixin (breakOnNan("hours"));
             time = makeTime(hours, minutes, seconds, ms);
             goto case;
         case 3:
-            date = arglist[2].toDtime();
+            date = arglist[2].toDtime(cc);
             goto case;
         case 2:
-            month = arglist[1].toDtime();
-            year = arglist[0].toDtime();
+            month = arglist[1].toDtime(cc);
+            year = arglist[0].toDtime(cc);
 
             if(year != d_time_nan && year >= 0 && year <= 99)
                 year += 1900;
@@ -260,14 +260,14 @@ class DdateConstructor : Dfunction
             break;
 
         case 1:
-            arglist[0].toPrimitive(ret, null);
+            arglist[0].toPrimitive(cc, ret, null);
             if(ret.getType() == TypeString)
             {
                 n = parseDateString(cc, ret.string);
             }
             else
             {
-                n = ret.toDtime();
+                n = ret.toDtime(cc);
                 n = timeClip(n);
             }
             break;
@@ -277,7 +277,7 @@ class DdateConstructor : Dfunction
             break;
         }
         //writefln("\tn = %s", n);
-        o = new Ddate(n);
+        o = new Ddate(cc, n);
         ret.putVobject(o);
         return null;
     }
@@ -308,11 +308,11 @@ class DdateConstructor : Dfunction
 
 /* ===================== Ddate.prototype functions =============== */
 
-void *checkdate(Value* ret, d_string name, Dobject othis)
+void *checkdate(Value* ret, CallContext* cc, d_string name, Dobject othis)
 {
     ret.putVundefined();
     ErrInfo errinfo;
-    return Dobject.RuntimeError(&errinfo, errmsgtbl[ERR_FUNCTION_WANTS_DATE],
+    return Dobject.RuntimeError(&errinfo, cc, errmsgtbl[ERR_FUNCTION_WANTS_DATE],
                                 name, othis.classname);
 }
 
@@ -347,7 +347,7 @@ void* Ddate_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis, Va
 
     //writefln("Ddate_prototype_toString()");
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_toString, othis);
+        return checkdate(ret, cc, TEXT_toString, othis);
 
     version(DATETOSTRING)
     {
@@ -370,7 +370,7 @@ void* Ddate_prototype_toDateString(Dobject pthis, CallContext *cc, Dobject othis
     immutable(char)[] s;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_toDateString, othis);
+        return checkdate(ret, cc, TEXT_toDateString, othis);
 
     version(DATETOSTRING)
     {
@@ -393,7 +393,7 @@ void* Ddate_prototype_toTimeString(Dobject pthis, CallContext *cc, Dobject othis
     immutable(char)[] s;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_toTimeString, othis);
+        return checkdate(ret, cc, TEXT_toTimeString, othis);
 
     version(DATETOSTRING)
     {
@@ -416,7 +416,7 @@ void* Ddate_prototype_valueOf(Dobject pthis, CallContext *cc, Dobject othis, Val
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_valueOf, othis);
+        return checkdate(ret, cc, TEXT_valueOf, othis);
     getThisTime(ret, othis, n);
     return null;
 }
@@ -427,7 +427,7 @@ void* Ddate_prototype_getTime(Dobject pthis, CallContext *cc, Dobject othis, Val
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getTime, othis);
+        return checkdate(ret, cc, TEXT_getTime, othis);
     getThisTime(ret, othis, n);
     return null;
 }
@@ -438,7 +438,7 @@ void* Ddate_prototype_getYear(Dobject pthis, CallContext *cc, Dobject othis, Val
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getYear, othis);
+        return checkdate(ret, cc, TEXT_getYear, othis);
 
     if(getThisLocalTime(ret, othis, n) == 0)
     {
@@ -463,7 +463,7 @@ void* Ddate_prototype_getFullYear(Dobject pthis, CallContext *cc, Dobject othis,
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getFullYear, othis);
+        return checkdate(ret, cc, TEXT_getFullYear, othis);
 
     if(getThisLocalTime(ret, othis, n) == 0)
     {
@@ -479,7 +479,7 @@ void* Ddate_prototype_getUTCFullYear(Dobject pthis, CallContext *cc, Dobject oth
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getUTCFullYear, othis);
+        return checkdate(ret, cc, TEXT_getUTCFullYear, othis);
     if(getThisTime(ret, othis, n) == 0)
     {
         n = yearFromTime(n);
@@ -494,7 +494,7 @@ void* Ddate_prototype_getMonth(Dobject pthis, CallContext *cc, Dobject othis, Va
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getMonth, othis);
+        return checkdate(ret, cc, TEXT_getMonth, othis);
 
     if(getThisLocalTime(ret, othis, n) == 0)
     {
@@ -510,7 +510,7 @@ void* Ddate_prototype_getUTCMonth(Dobject pthis, CallContext *cc, Dobject othis,
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getUTCMonth, othis);
+        return checkdate(ret, cc, TEXT_getUTCMonth, othis);
 
     if(getThisTime(ret, othis, n) == 0)
     {
@@ -526,7 +526,7 @@ void* Ddate_prototype_getDate(Dobject pthis, CallContext *cc, Dobject othis, Val
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getDate, othis);
+        return checkdate(ret, cc, TEXT_getDate, othis);
 
     if(getThisLocalTime(ret, othis, n) == 0)
     {
@@ -544,7 +544,7 @@ void* Ddate_prototype_getUTCDate(Dobject pthis, CallContext *cc, Dobject othis, 
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getUTCDate, othis);
+        return checkdate(ret, cc, TEXT_getUTCDate, othis);
 
     if(getThisTime(ret, othis, n) == 0)
     {
@@ -560,7 +560,7 @@ void* Ddate_prototype_getDay(Dobject pthis, CallContext *cc, Dobject othis, Valu
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getDay, othis);
+        return checkdate(ret, cc, TEXT_getDay, othis);
 
     if(getThisLocalTime(ret, othis, n) == 0)
     {
@@ -576,7 +576,7 @@ void* Ddate_prototype_getUTCDay(Dobject pthis, CallContext *cc, Dobject othis, V
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getUTCDay, othis);
+        return checkdate(ret, cc, TEXT_getUTCDay, othis);
 
     if(getThisTime(ret, othis, n) == 0)
     {
@@ -592,7 +592,7 @@ void* Ddate_prototype_getHours(Dobject pthis, CallContext *cc, Dobject othis, Va
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getHours, othis);
+        return checkdate(ret, cc, TEXT_getHours, othis);
 
     if(getThisLocalTime(ret, othis, n) == 0)
     {
@@ -608,7 +608,7 @@ void* Ddate_prototype_getUTCHours(Dobject pthis, CallContext *cc, Dobject othis,
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getUTCHours, othis);
+        return checkdate(ret, cc, TEXT_getUTCHours, othis);
 
     if(getThisTime(ret, othis, n) == 0)
     {
@@ -624,7 +624,7 @@ void* Ddate_prototype_getMinutes(Dobject pthis, CallContext *cc, Dobject othis, 
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getMinutes, othis);
+        return checkdate(ret, cc, TEXT_getMinutes, othis);
 
     if(getThisLocalTime(ret, othis, n) == 0)
     {
@@ -640,7 +640,7 @@ void* Ddate_prototype_getUTCMinutes(Dobject pthis, CallContext *cc, Dobject othi
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getUTCMinutes, othis);
+        return checkdate(ret, cc, TEXT_getUTCMinutes, othis);
 
     if(getThisTime(ret, othis, n) == 0)
     {
@@ -656,7 +656,7 @@ void* Ddate_prototype_getSeconds(Dobject pthis, CallContext *cc, Dobject othis, 
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getSeconds, othis);
+        return checkdate(ret, cc, TEXT_getSeconds, othis);
 
     if(getThisLocalTime(ret, othis, n) == 0)
     {
@@ -672,7 +672,7 @@ void* Ddate_prototype_getUTCSeconds(Dobject pthis, CallContext *cc, Dobject othi
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getUTCSeconds, othis);
+        return checkdate(ret, cc, TEXT_getUTCSeconds, othis);
 
     if(getThisTime(ret, othis, n) == 0)
     {
@@ -688,7 +688,7 @@ void* Ddate_prototype_getMilliseconds(Dobject pthis, CallContext *cc, Dobject ot
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getMilliseconds, othis);
+        return checkdate(ret, cc, TEXT_getMilliseconds, othis);
 
     if(getThisLocalTime(ret, othis, n) == 0)
     {
@@ -704,7 +704,7 @@ void* Ddate_prototype_getUTCMilliseconds(Dobject pthis, CallContext *cc, Dobject
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getUTCMilliseconds, othis);
+        return checkdate(ret, cc, TEXT_getUTCMilliseconds, othis);
 
     if(getThisTime(ret, othis, n) == 0)
     {
@@ -720,7 +720,7 @@ void* Ddate_prototype_getTimezoneOffset(Dobject pthis, CallContext *cc, Dobject 
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_getTimezoneOffset, othis);
+        return checkdate(ret, cc, TEXT_getTimezoneOffset, othis);
 
     if(getThisTime(ret, othis, n) == 0)
     {
@@ -736,12 +736,12 @@ void* Ddate_prototype_setTime(Dobject pthis, CallContext *cc, Dobject othis, Val
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setTime, othis);
+        return checkdate(ret, cc, TEXT_setTime, othis);
 
     if(!arglist.length)
         n = d_time_nan;
     else
-        n = arglist[0].toDtime();
+        n = arglist[0].toDtime(cc);
     n = timeClip(n);
     othis.value.putVtime(n);
     ret.putVtime(n);
@@ -758,14 +758,14 @@ void* Ddate_prototype_setMilliseconds(Dobject pthis, CallContext *cc, Dobject ot
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setMilliseconds, othis);
+        return checkdate(ret, cc, TEXT_setMilliseconds, othis);
 
     if(getThisLocalTime(ret, othis, t) == 0)
     {
         if(!arglist.length)
             ms = d_time_nan;
         else
-            ms = arglist[0].toDtime();
+            ms = arglist[0].toDtime(cc);
         time = makeTime(hourFromTime(t), minFromTime(t), secFromTime(t), ms);
         n = timeClip(localTimetoUTC(makeDate(day(t), time)));
         othis.value.putVtime(n);
@@ -783,14 +783,14 @@ void* Ddate_prototype_setUTCMilliseconds(Dobject pthis, CallContext *cc, Dobject
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setUTCMilliseconds, othis);
+        return checkdate(ret, cc, TEXT_setUTCMilliseconds, othis);
 
     if(getThisTime(ret, othis, t) == 0)
     {
         if(!arglist.length)
             ms = d_time_nan;
         else
-            ms = arglist[0].toDtime();
+            ms = arglist[0].toDtime(cc);
         time = makeTime(hourFromTime(t), minFromTime(t), secFromTime(t), ms);
         n = timeClip(makeDate(day(t), time));
         othis.value.putVtime(n);
@@ -809,7 +809,7 @@ void* Ddate_prototype_setSeconds(Dobject pthis, CallContext *cc, Dobject othis, 
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setSeconds, othis);
+        return checkdate(ret, cc, TEXT_setSeconds, othis);
 
     if(getThisLocalTime(ret, othis, t) == 0)
     {
@@ -817,13 +817,13 @@ void* Ddate_prototype_setSeconds(Dobject pthis, CallContext *cc, Dobject othis, 
         {
         default:
         case 2:
-            ms = arglist[1].toDtime();
-            seconds = arglist[0].toDtime();
+            ms = arglist[1].toDtime(cc);
+            seconds = arglist[0].toDtime(cc);
             break;
 
         case 1:
             ms = msFromTime(t);
-            seconds = arglist[0].toDtime();
+            seconds = arglist[0].toDtime(cc);
             break;
 
         case 0:
@@ -849,7 +849,7 @@ void* Ddate_prototype_setUTCSeconds(Dobject pthis, CallContext *cc, Dobject othi
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setUTCSeconds, othis);
+        return checkdate(ret, cc, TEXT_setUTCSeconds, othis);
 
     if(getThisTime(ret, othis, t) == 0)
     {
@@ -857,13 +857,13 @@ void* Ddate_prototype_setUTCSeconds(Dobject pthis, CallContext *cc, Dobject othi
         {
         default:
         case 2:
-            ms = arglist[1].toDtime();
-            seconds = arglist[0].toDtime();
+            ms = arglist[1].toDtime(cc);
+            seconds = arglist[0].toDtime(cc);
             break;
 
         case 1:
             ms = msFromTime(t);
-            seconds = arglist[0].toDtime();
+            seconds = arglist[0].toDtime(cc);
             break;
 
         case 0:
@@ -890,7 +890,7 @@ void* Ddate_prototype_setMinutes(Dobject pthis, CallContext *cc, Dobject othis, 
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setMinutes, othis);
+        return checkdate(ret, cc, TEXT_setMinutes, othis);
 
     if(getThisLocalTime(ret, othis, t) == 0)
     {
@@ -898,21 +898,21 @@ void* Ddate_prototype_setMinutes(Dobject pthis, CallContext *cc, Dobject othis, 
         {
         default:
         case 3:
-            ms = arglist[2].toDtime();
-            seconds = arglist[1].toDtime();
-            minutes = arglist[0].toDtime();
+            ms = arglist[2].toDtime(cc);
+            seconds = arglist[1].toDtime(cc);
+            minutes = arglist[0].toDtime(cc);
             break;
 
         case 2:
             ms = msFromTime(t);
-            seconds = arglist[1].toDtime();
-            minutes = arglist[0].toDtime();
+            seconds = arglist[1].toDtime(cc);
+            minutes = arglist[0].toDtime(cc);
             break;
 
         case 1:
             ms = msFromTime(t);
             seconds = secFromTime(t);
-            minutes = arglist[0].toDtime();
+            minutes = arglist[0].toDtime(cc);
             break;
 
         case 0:
@@ -940,7 +940,7 @@ void* Ddate_prototype_setUTCMinutes(Dobject pthis, CallContext *cc, Dobject othi
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setUTCMinutes, othis);
+        return checkdate(ret, cc, TEXT_setUTCMinutes, othis);
 
     if(getThisTime(ret, othis, t) == 0)
     {
@@ -948,21 +948,21 @@ void* Ddate_prototype_setUTCMinutes(Dobject pthis, CallContext *cc, Dobject othi
         {
         default:
         case 3:
-            ms = arglist[2].toDtime();
-            seconds = arglist[1].toDtime();
-            minutes = arglist[0].toDtime();
+            ms = arglist[2].toDtime(cc);
+            seconds = arglist[1].toDtime(cc);
+            minutes = arglist[0].toDtime(cc);
             break;
 
         case 2:
             ms = msFromTime(t);
-            seconds = arglist[1].toDtime();
-            minutes = arglist[0].toDtime();
+            seconds = arglist[1].toDtime(cc);
+            minutes = arglist[0].toDtime(cc);
             break;
 
         case 1:
             ms = msFromTime(t);
             seconds = secFromTime(t);
-            minutes = arglist[0].toDtime();
+            minutes = arglist[0].toDtime(cc);
             break;
 
         case 0:
@@ -991,7 +991,7 @@ void* Ddate_prototype_setHours(Dobject pthis, CallContext *cc, Dobject othis, Va
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setHours, othis);
+        return checkdate(ret, cc, TEXT_setHours, othis);
 
     if(getThisLocalTime(ret, othis, t) == 0)
     {
@@ -999,31 +999,31 @@ void* Ddate_prototype_setHours(Dobject pthis, CallContext *cc, Dobject othis, Va
         {
         default:
         case 4:
-            ms = arglist[3].toDtime();
-            seconds = arglist[2].toDtime();
-            minutes = arglist[1].toDtime();
-            hours = arglist[0].toDtime();
+            ms = arglist[3].toDtime(cc);
+            seconds = arglist[2].toDtime(cc);
+            minutes = arglist[1].toDtime(cc);
+            hours = arglist[0].toDtime(cc);
             break;
 
         case 3:
             ms = msFromTime(t);
-            seconds = arglist[2].toDtime();
-            minutes = arglist[1].toDtime();
-            hours = arglist[0].toDtime();
+            seconds = arglist[2].toDtime(cc);
+            minutes = arglist[1].toDtime(cc);
+            hours = arglist[0].toDtime(cc);
             break;
 
         case 2:
             ms = msFromTime(t);
             seconds = secFromTime(t);
-            minutes = arglist[1].toDtime();
-            hours = arglist[0].toDtime();
+            minutes = arglist[1].toDtime(cc);
+            hours = arglist[0].toDtime(cc);
             break;
 
         case 1:
             ms = msFromTime(t);
             seconds = secFromTime(t);
             minutes = minFromTime(t);
-            hours = arglist[0].toDtime();
+            hours = arglist[0].toDtime(cc);
             break;
 
         case 0:
@@ -1053,7 +1053,7 @@ void* Ddate_prototype_setUTCHours(Dobject pthis, CallContext *cc, Dobject othis,
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setUTCHours, othis);
+        return checkdate(ret, cc, TEXT_setUTCHours, othis);
 
     if(getThisTime(ret, othis, t) == 0)
     {
@@ -1061,31 +1061,31 @@ void* Ddate_prototype_setUTCHours(Dobject pthis, CallContext *cc, Dobject othis,
         {
         default:
         case 4:
-            ms = arglist[3].toDtime();
-            seconds = arglist[2].toDtime();
-            minutes = arglist[1].toDtime();
-            hours = arglist[0].toDtime();
+            ms = arglist[3].toDtime(cc);
+            seconds = arglist[2].toDtime(cc);
+            minutes = arglist[1].toDtime(cc);
+            hours = arglist[0].toDtime(cc);
             break;
 
         case 3:
             ms = msFromTime(t);
-            seconds = arglist[2].toDtime();
-            minutes = arglist[1].toDtime();
-            hours = arglist[0].toDtime();
+            seconds = arglist[2].toDtime(cc);
+            minutes = arglist[1].toDtime(cc);
+            hours = arglist[0].toDtime(cc);
             break;
 
         case 2:
             ms = msFromTime(t);
             seconds = secFromTime(t);
-            minutes = arglist[1].toDtime();
-            hours = arglist[0].toDtime();
+            minutes = arglist[1].toDtime(cc);
+            hours = arglist[0].toDtime(cc);
             break;
 
         case 1:
             ms = msFromTime(t);
             seconds = secFromTime(t);
             minutes = minFromTime(t);
-            hours = arglist[0].toDtime();
+            hours = arglist[0].toDtime(cc);
             break;
 
         case 0:
@@ -1112,14 +1112,14 @@ void* Ddate_prototype_setDate(Dobject pthis, CallContext *cc, Dobject othis, Val
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setDate, othis);
+        return checkdate(ret, cc, TEXT_setDate, othis);
 
     if(getThisLocalTime(ret, othis, t) == 0)
     {
         if(!arglist.length)
             date = d_time_nan;
         else
-            date = arglist[0].toDtime();
+            date = arglist[0].toDtime(cc);
         day = makeDay(yearFromTime(t), monthFromTime(t), date);
         n = timeClip(localTimetoUTC(makeDate(day, timeWithinDay(t))));
         othis.value.putVtime(n);
@@ -1137,14 +1137,14 @@ void* Ddate_prototype_setUTCDate(Dobject pthis, CallContext *cc, Dobject othis, 
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setUTCDate, othis);
+        return checkdate(ret, cc, TEXT_setUTCDate, othis);
 
     if(getThisTime(ret, othis, t) == 0)
     {
         if(!arglist.length)
             date = d_time_nan;
         else
-            date = arglist[0].toDtime();
+            date = arglist[0].toDtime(cc);
         day = makeDay(yearFromTime(t), monthFromTime(t), date);
         n = timeClip(makeDate(day, timeWithinDay(t)));
         othis.value.putVtime(n);
@@ -1163,7 +1163,7 @@ void* Ddate_prototype_setMonth(Dobject pthis, CallContext *cc, Dobject othis, Va
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setMonth, othis);
+        return checkdate(ret, cc, TEXT_setMonth, othis);
 
     if(getThisLocalTime(ret, othis, t) == 0)
     {
@@ -1171,12 +1171,12 @@ void* Ddate_prototype_setMonth(Dobject pthis, CallContext *cc, Dobject othis, Va
         {
         default:
         case 2:
-            month = arglist[0].toDtime();
-            date = arglist[1].toDtime();
+            month = arglist[0].toDtime(cc);
+            date = arglist[1].toDtime(cc);
             break;
 
         case 1:
-            month = arglist[0].toDtime();
+            month = arglist[0].toDtime(cc);
             date = dateFromTime(t);
             break;
 
@@ -1203,7 +1203,7 @@ void* Ddate_prototype_setUTCMonth(Dobject pthis, CallContext *cc, Dobject othis,
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setUTCMonth, othis);
+        return checkdate(ret, cc, TEXT_setUTCMonth, othis);
 
     if(getThisTime(ret, othis, t) == 0)
     {
@@ -1211,12 +1211,12 @@ void* Ddate_prototype_setUTCMonth(Dobject pthis, CallContext *cc, Dobject othis,
         {
         default:
         case 2:
-            month = arglist[0].toDtime();
-            date = arglist[1].toDtime();
+            month = arglist[0].toDtime(cc);
+            date = arglist[1].toDtime(cc);
             break;
 
         case 1:
-            month = arglist[0].toDtime();
+            month = arglist[0].toDtime(cc);
             date = dateFromTime(t);
             break;
 
@@ -1244,7 +1244,7 @@ void* Ddate_prototype_setFullYear(Dobject pthis, CallContext *cc, Dobject othis,
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setFullYear, othis);
+        return checkdate(ret, cc, TEXT_setFullYear, othis);
 
     if(getThisLocalTime(ret, othis, t))
         t = 0;
@@ -1253,21 +1253,21 @@ void* Ddate_prototype_setFullYear(Dobject pthis, CallContext *cc, Dobject othis,
     {
     default:
     case 3:
-        date = arglist[2].toDtime();
-        month = arglist[1].toDtime();
-        year = arglist[0].toDtime();
+        date = arglist[2].toDtime(cc);
+        month = arglist[1].toDtime(cc);
+        year = arglist[0].toDtime(cc);
         break;
 
     case 2:
         date = dateFromTime(t);
-        month = arglist[1].toDtime();
-        year = arglist[0].toDtime();
+        month = arglist[1].toDtime(cc);
+        year = arglist[0].toDtime(cc);
         break;
 
     case 1:
         date = dateFromTime(t);
         month = monthFromTime(t);
-        year = arglist[0].toDtime();
+        year = arglist[0].toDtime(cc);
         break;
 
     case 0:
@@ -1294,7 +1294,7 @@ void* Ddate_prototype_setUTCFullYear(Dobject pthis, CallContext *cc, Dobject oth
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setUTCFullYear, othis);
+        return checkdate(ret, cc, TEXT_setUTCFullYear, othis);
 
     getThisTime(ret, othis, t);
     if(t == d_time_nan)
@@ -1303,21 +1303,21 @@ void* Ddate_prototype_setUTCFullYear(Dobject pthis, CallContext *cc, Dobject oth
     {
     default:
     case 3:
-        month = arglist[2].toDtime();
-        date = arglist[1].toDtime();
-        year = arglist[0].toDtime();
+        month = arglist[2].toDtime(cc);
+        date = arglist[1].toDtime(cc);
+        year = arglist[0].toDtime(cc);
         break;
 
     case 2:
         month = monthFromTime(t);
-        date = arglist[1].toDtime();
-        year = arglist[0].toDtime();
+        date = arglist[1].toDtime(cc);
+        year = arglist[0].toDtime(cc);
         break;
 
     case 1:
         month = monthFromTime(t);
         date = dateFromTime(t);
-        year = arglist[0].toDtime();
+        year = arglist[0].toDtime(cc);
         break;
 
     case 0:
@@ -1344,7 +1344,7 @@ void* Ddate_prototype_setYear(Dobject pthis, CallContext *cc, Dobject othis, Val
     d_time n;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_setYear, othis);
+        return checkdate(ret, cc, TEXT_setYear, othis);
 
     if(getThisLocalTime(ret, othis, t))
         t = 0;
@@ -1354,7 +1354,7 @@ void* Ddate_prototype_setYear(Dobject pthis, CallContext *cc, Dobject othis, Val
     case 1:
         month = monthFromTime(t);
         date = dateFromTime(t);
-        year = arglist[0].toDtime();
+        year = arglist[0].toDtime(cc);
         if(0 <= year && year <= 99)
             year += 1900;
         day = makeDay(year, month, date);
@@ -1377,7 +1377,7 @@ void* Ddate_prototype_toLocaleString(Dobject pthis, CallContext *cc, Dobject oth
     d_time t;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_toLocaleString, othis);
+        return checkdate(ret, cc, TEXT_toLocaleString, othis);
 
     if(getThisLocalTime(ret, othis, t))
         t = 0;
@@ -1394,7 +1394,7 @@ void* Ddate_prototype_toLocaleDateString(Dobject pthis, CallContext *cc, Dobject
     d_time t;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_toLocaleDateString, othis);
+        return checkdate(ret, cc, TEXT_toLocaleDateString, othis);
 
     if(getThisLocalTime(ret, othis, t))
         t = 0;
@@ -1411,7 +1411,7 @@ void* Ddate_prototype_toLocaleTimeString(Dobject pthis, CallContext *cc, Dobject
     d_time t;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_toLocaleTimeString, othis);
+        return checkdate(ret, cc, TEXT_toLocaleTimeString, othis);
 
     if(getThisLocalTime(ret, othis, t))
         t = 0;
@@ -1427,7 +1427,7 @@ void* Ddate_prototype_toUTCString(Dobject pthis, CallContext *cc, Dobject othis,
     d_time t;
 
     if(!othis.isDdate())
-        return checkdate(ret, TEXT_toUTCString, othis);
+        return checkdate(ret, cc, TEXT_toUTCString, othis);
 
     if(getThisTime(ret, othis, t))
         t = 0;
@@ -1440,13 +1440,13 @@ void* Ddate_prototype_toUTCString(Dobject pthis, CallContext *cc, Dobject othis,
 
 class DdatePrototype : Ddate
 {
-    this()
+    this(CallContext* cc)
     {
-        super(Dobject_prototype);
+        super(cc, Dobject_prototype);
 
         Dobject f = Dfunction_prototype;
 
-        Put(TEXT_constructor, Ddate_constructor, DontEnum);
+        Put(cc, TEXT_constructor, Ddate_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -1499,7 +1499,7 @@ class DdatePrototype : Ddate
             { TEXT_toGMTString, &Ddate_prototype_toUTCString, 0 },
         ];
 
-        DnativeFunction.initialize(this, nfd, DontEnum);
+        DnativeFunction.initialize(this, cc, nfd, DontEnum);
         assert(proptable.get("toString", Value.calcHash("toString")));
     }
 }
@@ -1509,33 +1509,33 @@ class DdatePrototype : Ddate
 
 class Ddate : Dobject
 {
-    this(d_number n)
+    this(CallContext* cc, d_number n)
     {
-        super(Ddate.getPrototype());
+        super(cc, Ddate.getPrototype());
         classname = TEXT_Date;
         value.putVnumber(n);
     }
 
-    this(d_time n)
+    this(CallContext* cc, d_time n)
     {
-        super(Ddate.getPrototype());
+        super(cc, Ddate.getPrototype());
         classname = TEXT_Date;
         value.putVtime(n);
     }
 
-    this(Dobject prototype)
+    this(CallContext* cc, Dobject prototype)
     {
-        super(prototype);
+        super(cc, prototype);
         classname = TEXT_Date;
         value.putVnumber(d_number.nan);
     }
 
-    static void initialize()
+    static void initialize(CallContext* cc)
     {
-        Ddate_constructor = new DdateConstructor();
-        Ddate_prototype = new DdatePrototype();
+        Ddate_constructor = new DdateConstructor(cc);
+        Ddate_prototype = new DdatePrototype(cc);
 
-        Ddate_constructor.Put(TEXT_prototype, Ddate_prototype,
+        Ddate_constructor.Put(cc, TEXT_prototype, Ddate_prototype,
                                  DontEnum | DontDelete | ReadOnly);
 
         assert(Ddate_prototype.proptable.table.length != 0);

--- a/engine/source/dmdscript/ddeclaredfunction.d
+++ b/engine/source/dmdscript/ddeclaredfunction.d
@@ -38,9 +38,9 @@ class DdeclaredFunction : Dfunction
 {
     FunctionDefinition fd;
 
-    this(FunctionDefinition fd)
+    this(CallContext* cc, FunctionDefinition fd)
     {
-        super(cast(uint)fd.parameters.length, Dfunction.getPrototype());
+        super(cc, cast(uint)fd.parameters.length, Dfunction.getPrototype());
         assert(Dfunction.getPrototype());
         assert(internal_prototype);
         this.fd = fd;
@@ -48,9 +48,9 @@ class DdeclaredFunction : Dfunction
         Dobject o;
 
         // ECMA 3 13.2
-        o = new Dobject(Dobject.getPrototype());        // step 9
-        Put(TEXT_prototype, o, DontEnum);               // step 11
-        o.Put(TEXT_constructor, this, DontEnum);        // step 10
+        o = new Dobject(cc, Dobject.getPrototype());        // step 9
+        Put(cc, TEXT_prototype, o, DontEnum);               // step 11
+        o.Put(cc, TEXT_constructor, this, DontEnum);        // step 10
     }
 
     override void *Call(CallContext *cc, Dobject othis, Value* ret, Value[] arglist)
@@ -78,12 +78,12 @@ class DdeclaredFunction : Dfunction
 
         // Generate the activation object
         // ECMA v3 10.1.6
-        actobj = new Dobject(null);
+        actobj = new Dobject(cc, null);
         
         Value vtmp;//should not be referenced by the end of func
         if(fd.name){ 
            vtmp.putVobject(this);
-           actobj.Put(fd.name,&vtmp,DontDelete);
+           actobj.Put(cc, fd.name,&vtmp,DontDelete);
         }
         // Instantiate the parameters
         {
@@ -91,15 +91,15 @@ class DdeclaredFunction : Dfunction
             foreach(Identifier* p; fd.parameters)
             {
                 Value* v = (a < arglist.length) ? &arglist[a++] : &vundefined;
-                actobj.Put(p.toString(), v, DontDelete);
+                actobj.Put(cc, p.toString(), v, DontDelete);
             }
         }
 
         // Generate the Arguments Object
         // ECMA v3 10.1.8
-        args = new Darguments(cc.caller, this, actobj, fd.parameters, arglist);
+        args = new Darguments(cc, cc.caller, this, actobj, fd.parameters, arglist);
 
-        actobj.Put(TEXT_arguments, args, DontDelete);
+        actobj.Put(cc, TEXT_arguments, args, DontDelete);
 
         // The following is not specified by ECMA, but seems to be supported
         // by jscript. The url www.grannymail.com has the following code
@@ -111,7 +111,7 @@ class DdeclaredFunction : Dfunction
         //		  this[i+1] = arguments[i]
         //	    }
         //	    var cardpic = new MakeArray("LL","AP","BA","MB","FH","AW","CW","CV","DZ");
-        Put(TEXT_arguments, args, DontDelete);          // make grannymail bug work
+        Put(cc, TEXT_arguments, args, DontDelete);          // make grannymail bug work
 
         
         
@@ -121,7 +121,7 @@ class DdeclaredFunction : Dfunction
         assert(newScopex.length != 0);
         newScopex ~= actobj;//and put activation object on top of it
         
-        fd.instantiate(newScopex, actobj, DontDelete);
+        fd.instantiate(cc, newScopex, actobj, DontDelete);
 
         Dobject[] scopesave = cc.scopex;
         cc.scopex = newScopex; 
@@ -160,7 +160,7 @@ class DdeclaredFunction : Dfunction
         //Value* v;
         //v=Get(TEXT_arguments);
         //writef("1v = %x, %s, v.object = %x\n", v, v.getType(), v.object);
-        Put(TEXT_arguments, &vundefined, 0);
+        Put(cc, TEXT_arguments, &vundefined, 0);
         //actobj.Put(TEXT_arguments, &vundefined, 0);
 
         version(none)
@@ -195,8 +195,8 @@ class DdeclaredFunction : Dfunction
         if(v.isPrimitive())
             proto = Dobject.getPrototype();
         else
-            proto = v.toObject();
-        othis = new Dobject(proto);
+            proto = v.toObject(cc);
+        othis = new Dobject(cc, proto);
         result = Call(cc, othis, ret, arglist);
         if(!result)
         {

--- a/engine/source/dmdscript/derror.d
+++ b/engine/source/dmdscript/derror.d
@@ -34,9 +34,9 @@ const uint FACILITY = 0x800A0000;
 
 class DerrorConstructor : Dfunction
 {
-    this()
+    this(CallContext* cc)
     {
-        super(1, Dfunction_prototype);
+        super(cc, 1, Dfunction_prototype);
     }
 
     override void* Construct(CallContext *cc, Value *ret, Value[] arglist)
@@ -69,7 +69,7 @@ class DerrorConstructor : Dfunction
             n = &arglist[1];
             break;
         }
-        o = new Derror(m, n);
+        o = new Derror(cc, m, n);
         ret.putVobject(o);
         return null;
     }
@@ -94,7 +94,7 @@ void* Derror_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis, V
     v = othis.Get(TEXT_message);
     if(!v)
         v = &vundefined;
-    ret.putVstring(othis.Get(TEXT_name).toString()~": "~v.toString());
+    ret.putVstring(othis.Get(TEXT_name).toString(cc)~": "~v.toString(cc));
     return null;
 }
 
@@ -102,25 +102,25 @@ void* Derror_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis, V
 
 class DerrorPrototype : Derror
 {
-    this()
+    this(CallContext* cc)
     {
-        super(Dobject_prototype);
+        super(cc, Dobject_prototype);
         Dobject f = Dfunction_prototype;
         //d_string m = d_string_ctor(DTEXT("Error.prototype.message"));
 
-        Put(TEXT_constructor, Derror_constructor, DontEnum);
+        Put(cc, TEXT_constructor, Derror_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
             { TEXT_toString, &Derror_prototype_toString, 0 },
         ];
 
-        DnativeFunction.initialize(this, nfd, 0);
+        DnativeFunction.initialize(this, cc, nfd, 0);
 
-        Put(TEXT_name, TEXT_Error, 0);
-        Put(TEXT_message, TEXT_, 0);
-        Put(TEXT_description, TEXT_, 0);
-        Put(TEXT_number, cast(d_number)(/*FACILITY |*/ 0), 0);
+        Put(cc, TEXT_name, TEXT_Error, 0);
+        Put(cc, TEXT_message, TEXT_, 0);
+        Put(cc, TEXT_description, TEXT_, 0);
+        Put(cc, TEXT_number, cast(d_number)(/*FACILITY |*/ 0), 0);
     }
 }
 
@@ -129,40 +129,40 @@ class DerrorPrototype : Derror
 
 class Derror : Dobject
 {
-    this(Value * m, Value * v2)
+    this(CallContext* cc, Value * m, Value * v2)
     {
-        super(getPrototype());
+        super(cc, getPrototype());
         classname = TEXT_Error;
 
         immutable(char)[] msg;
-        msg = m.toString();
-        Put(TEXT_message, msg, 0);
-        Put(TEXT_description, msg, 0);
+        msg = m.toString(cc);
+        Put(cc, TEXT_message, msg, 0);
+        Put(cc, TEXT_description, msg, 0);
         if(m.isString())
         {
         }
         else if(m.isNumber())
         {
-            d_number n = m.toNumber();
+            d_number n = m.toNumber(cc);
             n = cast(d_number)(/*FACILITY |*/ cast(int)n);
-            Put(TEXT_number, n, 0);
+            Put(cc, TEXT_number, n, 0);
         }
         if(v2.isString())
         {
-            Put(TEXT_description, v2.toString(), 0);
-            Put(TEXT_message, v2.toString(), 0);
+            Put(cc, TEXT_description, v2.toString(cc), 0);
+            Put(cc, TEXT_message, v2.toString(cc), 0);
         }
         else if(v2.isNumber())
         {
-            d_number n = v2.toNumber();
+            d_number n = v2.toNumber(cc);
             n = cast(d_number)(/*FACILITY |*/ cast(int)n);
-            Put(TEXT_number, n, 0);
+            Put(cc, TEXT_number, n, 0);
         }
     }
 
-    this(Dobject prototype)
+    this(CallContext* cc, Dobject prototype)
     {
-        super(prototype);
+        super(cc, prototype);
         classname = TEXT_Error;
     }
 
@@ -176,12 +176,12 @@ class Derror : Dobject
         return Derror_prototype;
     }
 
-    static void initialize()
+    static void initialize(CallContext* cc)
     {
-        Derror_constructor = new DerrorConstructor();
-        Derror_prototype = new DerrorPrototype();
+        Derror_constructor = new DerrorConstructor(cc);
+        Derror_prototype = new DerrorPrototype(cc);
 
-        Derror_constructor.Put(TEXT_prototype, Derror_prototype, DontEnum | DontDelete | ReadOnly);
+        Derror_constructor.Put(cc, TEXT_prototype, Derror_prototype, DontEnum | DontDelete | ReadOnly);
     }
 }
 

--- a/engine/source/dmdscript/dfunction.d
+++ b/engine/source/dmdscript/dfunction.d
@@ -39,9 +39,9 @@ import dmdscript.ddeclaredfunction;
 
 class DfunctionConstructor : Dfunction
 {
-    this()
+    this(CallContext* cc)
     {
-        super(1, Dfunction_prototype);
+        super(cc, 1, Dfunction_prototype);
 
         // Actually put in later by Dfunction::initialize()
         //unsigned attributes = DontEnum | DontDelete | ReadOnly;
@@ -61,14 +61,14 @@ class DfunctionConstructor : Dfunction
         // Get parameter list (P) and body from arglist[]
         if(arglist.length)
         {
-            bdy = arglist[arglist.length - 1].toString();
+            bdy = arglist[arglist.length - 1].toString(cc);
             if(arglist.length >= 2)
             {
                 for(uint a = 0; a < arglist.length - 1; a++)
                 {
                     if(a)
                         P ~= ',';
-                    P ~= arglist[a].toString();
+                    P ~= arglist[a].toString(cc);
                 }
             }
         }
@@ -86,7 +86,7 @@ class DfunctionConstructor : Dfunction
             if(errinfo.message)
                 goto Lsyntaxerror;
             fd.toIR(null);
-            Dfunction fobj = new DdeclaredFunction(fd);
+            Dfunction fobj = new DdeclaredFunction(cc, fd);
             assert(cc.scoperoot <= cc.scopex.length);
             fobj.scopex = cc.scopex[0..cc.scoperoot].dup;
             ret.putVobject(fobj);
@@ -100,7 +100,7 @@ class DfunctionConstructor : Dfunction
         Dobject o;
 
         ret.putVundefined();
-        o = new syntaxerror.D0(&errinfo);
+        o = new syntaxerror.D0(cc, &errinfo);
         Value* v = new Value;
         v.putVobject(o);
         return v;
@@ -127,7 +127,7 @@ void* Dfunction_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis
     {
         ErrInfo errinfo;
         ret.putVundefined();
-        return Dobject.RuntimeError(&errinfo, ERR_TS_NOT_TRANSFERRABLE);
+        return Dobject.RuntimeError(&errinfo, cc, ERR_TS_NOT_TRANSFERRABLE);
     }
     else
     {
@@ -173,7 +173,7 @@ void* Dfunction_prototype_apply(Dobject pthis, CallContext *cc, Dobject othis, V
     if(thisArg.isUndefinedOrNull())
         o = cc.global;
     else
-        o = thisArg.toObject();
+        o = thisArg.toObject(cc);
 
     if(argArray.isUndefinedOrNull())
     {
@@ -186,11 +186,11 @@ void* Dfunction_prototype_apply(Dobject pthis, CallContext *cc, Dobject othis, V
             Ltypeerror:
             ret.putVundefined();
             ErrInfo errinfo;
-            return Dobject.RuntimeError(&errinfo, ERR_ARRAY_ARGS);
+            return Dobject.RuntimeError(&errinfo, cc, ERR_ARRAY_ARGS);
         }
         Dobject a;
 
-        a = argArray.toObject();
+        a = argArray.toObject(cc);
 
         // Must be array or arguments object
         if(!a.isDarray() && !a.isDarguments())
@@ -202,7 +202,7 @@ void* Dfunction_prototype_apply(Dobject pthis, CallContext *cc, Dobject othis, V
         Value* x;
 
         x = a.Get(TEXT_length);
-        len = x ? x.toUint32() : 0;
+        len = x ? x.toUint32(cc) : 0;
 
         Value[] p1;
         Value* v1;
@@ -249,7 +249,7 @@ void* Dfunction_prototype_call(Dobject pthis, CallContext *cc, Dobject othis, Va
         if(thisArg.isUndefinedOrNull())
             o = cc.global;
         else
-            o = thisArg.toObject();
+            o = thisArg.toObject(cc);
         v = othis.Call(cc, o, ret, arglist[1 .. $]);
     }
     return v;
@@ -259,15 +259,15 @@ void* Dfunction_prototype_call(Dobject pthis, CallContext *cc, Dobject othis, Va
 
 class DfunctionPrototype : Dfunction
 {
-    this()
+    this(CallContext* cc)
     {
-        super(0, Dobject_prototype);
+        super(cc, 0, Dobject_prototype);
 
         uint attributes = DontEnum;
 
         classname = TEXT_Function;
         name = "prototype";
-        Put(TEXT_constructor, Dfunction_constructor, attributes);
+        Put(cc, TEXT_constructor, Dfunction_constructor, attributes);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -276,7 +276,7 @@ class DfunctionPrototype : Dfunction
             { TEXT_call, &Dfunction_prototype_call, 1 },
         ];
 
-        DnativeFunction.initialize(this, nfd, attributes);
+        DnativeFunction.initialize(this, cc, nfd, attributes);
     }
 
     override void *Call(CallContext *cc, Dobject othis, Value* ret, Value[] arglist)
@@ -295,18 +295,18 @@ class Dfunction : Dobject
 { const (char)[] name;
   Dobject[] scopex;     // Function object's scope chain per 13.2 step 7
 
-  this(d_uint32 length)
+  this(CallContext* cc, d_uint32 length)
   {
-      this(length, Dfunction.getPrototype());
+      this(cc, length, Dfunction.getPrototype());
   }
 
-  this(d_uint32 length, Dobject prototype)
+  this(CallContext* cc, d_uint32 length, Dobject prototype)
   {
-      super(prototype);
+      super(cc, prototype);
       classname = TEXT_Function;
       name = TEXT_Function;
-      Put(TEXT_length, length, DontDelete | DontEnum | ReadOnly);
-      Put(TEXT_arity, length, DontDelete | DontEnum | ReadOnly);
+      Put(cc, TEXT_length, length, DontDelete | DontEnum | ReadOnly);
+      Put(cc, TEXT_arity, length, DontDelete | DontEnum | ReadOnly);
   }
 
   override immutable(char)[] getTypeof()
@@ -324,7 +324,7 @@ class Dfunction : Dobject
       return s;
   }
 
-  override void *HasInstance(Value* ret, Value* v)
+  override void *HasInstance(CallContext* cc, Value* ret, Value* v)
   {
       // ECMA v3 15.3.5.3
       Dobject V;
@@ -333,14 +333,14 @@ class Dfunction : Dobject
 
       if(v.isPrimitive())
           goto Lfalse;
-      V = v.toObject();
+      V = v.toObject(cc);
       w = Get(TEXT_prototype);
       if(w.isPrimitive())
       {
           ErrInfo errinfo;
-          return RuntimeError(&errinfo, errmsgtbl[ERR_MUST_BE_OBJECT], w.getType());
+          return RuntimeError(&errinfo, cc, errmsgtbl[ERR_MUST_BE_OBJECT], w.getType());
       }
-      o = w.toObject();
+      o = w.toObject(cc);
       for(;; )
       {
           V = V.internal_prototype;
@@ -359,7 +359,7 @@ class Dfunction : Dobject
       return null;
   }
 
-  static Dfunction isFunction(Value* v)
+  static Dfunction isFunction(Value* v, CallContext* cc)
   {
       Dfunction r;
       Dobject o;
@@ -367,7 +367,7 @@ class Dfunction : Dobject
       r = null;
       if(!v.isPrimitive())
       {
-          o = v.toObject();
+          o = v.toObject(cc);
           if(o.isClass(TEXT_Function))
               r = cast(Dfunction)o;
       }
@@ -385,12 +385,12 @@ class Dfunction : Dobject
       return Dfunction_prototype;
   }
 
-  static void initialize()
+  static void initialize(CallContext* cc)
   {
-      Dfunction_constructor = new DfunctionConstructor();
-      Dfunction_prototype = new DfunctionPrototype();
+      Dfunction_constructor = new DfunctionConstructor(cc);
+      Dfunction_prototype = new DfunctionPrototype(cc);
 
-      Dfunction_constructor.Put(TEXT_prototype, Dfunction_prototype, DontEnum | DontDelete | ReadOnly);
+      Dfunction_constructor.Put(cc, TEXT_prototype, Dfunction_prototype, DontEnum | DontDelete | ReadOnly);
 
       Dfunction_constructor.internal_prototype = Dfunction_prototype;
       Dfunction_constructor.proptable.previous = Dfunction_prototype.proptable;

--- a/engine/source/dmdscript/dglobal.d
+++ b/engine/source/dmdscript/dglobal.d
@@ -46,10 +46,10 @@ import dmdscript.dboolean;
 import dmdscript.dfunction;
 import dmdscript.dnative;
 
-immutable(char)[] arg0string(Value[] arglist)
+immutable(char)[] arg0string(Value[] arglist, CallContext* cc)
 {
     Value* v = arglist.length ? &arglist[0] : &vundefined;
-    return v.toString();
+    return v.toString(cc);
 }
 
 /* ====================== Dglobal_eval ================ */
@@ -71,7 +71,7 @@ void* Dglobal_eval(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Va
         Value.copy(ret, v);
         return null;
     }
-    s = v.toString();
+    s = v.toString(cc);
     //writef("eval('%ls')\n", s);
 
     // Parse program
@@ -148,7 +148,7 @@ void* Dglobal_eval(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Va
         // Variable instantiation is performed using the calling
         // context's variable object and using empty
         // property attributes
-        fd.instantiate(cc.scopex, cc.variable, 0);
+        fd.instantiate(cc, cc.scopex, cc.variable, 0);
 
         // The this value is the same as the this value of the
         // calling context.
@@ -168,7 +168,7 @@ Lsyntaxerror:
     errinfo.linnum = 0;
 
     ret.putVundefined();
-    o = new syntaxerror.D0(&errinfo);
+    o = new syntaxerror.D0(cc, &errinfo);
     Value* v2 = new Value;
     v2.putVobject(o);
     return v2;
@@ -190,7 +190,7 @@ void* Dglobal_parseInt(Dobject pthis, CallContext *cc, Dobject othis, Value* ret
     size_t i;
     d_string string;
 
-    string = arg0string(arglist);
+    string = arg0string(arglist, cc);
 
     //writefln("Dglobal_parseInt('%s')", string);
 
@@ -224,7 +224,7 @@ void* Dglobal_parseInt(Dobject pthis, CallContext *cc, Dobject othis, Value* ret
     if(arglist.length >= 2)
     {
         v2 = &arglist[1];
-        radix = v2.toInt32();
+        radix = v2.toInt32(cc);
     }
 
     if(radix)
@@ -307,7 +307,7 @@ void* Dglobal_parseFloat(Dobject pthis, CallContext *cc, Dobject othis, Value* r
     d_number n;
     size_t endidx;
 
-    d_string string = arg0string(arglist);
+    d_string string = arg0string(arglist, cc);
     n = StringNumericLiteral(string, endidx, 1);
 
     ret.putVnumber(n);
@@ -335,7 +335,7 @@ void* Dglobal_escape(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, 
     uint unicodes;
     size_t slen;
 
-    s = arg0string(arglist);
+    s = arg0string(arglist, cc);
     escapes = 0;
     unicodes = 0;
     foreach(dchar c; s)
@@ -398,7 +398,7 @@ void* Dglobal_unescape(Dobject pthis, CallContext *cc, Dobject othis, Value* ret
     d_string s;
     d_string R;
 
-    s = arg0string(arglist);
+    s = arg0string(arglist, cc);
     //writefln("Dglobal.unescape(s = '%s')", s);
     for(size_t k = 0; k < s.length; k++)
     {
@@ -483,7 +483,7 @@ void* Dglobal_isNaN(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, V
         v = &arglist[0];
     else
         v = &vundefined;
-    n = v.toNumber();
+    n = v.toNumber(cc);
     b = isNaN(n) ? true : false;
     ret.putVboolean(b);
     return null;
@@ -502,7 +502,7 @@ void* Dglobal_isFinite(Dobject pthis, CallContext *cc, Dobject othis, Value* ret
         v = &arglist[0];
     else
         v = &vundefined;
-    n = v.toNumber();
+    n = v.toNumber(cc);
     b = isFinite(n) ? true : false;
     ret.putVboolean(b);
     return null;
@@ -510,9 +510,9 @@ void* Dglobal_isFinite(Dobject pthis, CallContext *cc, Dobject othis, Value* ret
 
 /* ====================== Dglobal_ URI Functions ================ */
 
-void* URI_error(d_string s)
+void* URI_error(d_string s, CallContext* cc)
 {
-    Dobject o = new urierror.D0(s ~ "() failure");
+    Dobject o = new urierror.D0(cc, s ~ "() failure");
     Value* v = new Value;
     v.putVobject(o);
     return v;
@@ -523,7 +523,7 @@ void* Dglobal_decodeURI(Dobject pthis, CallContext *cc, Dobject othis, Value* re
     // ECMA v3 15.1.3.1
     d_string s;
 
-    s = arg0string(arglist);
+    s = arg0string(arglist, cc);
     try
     {
         s = std.uri.decode(s);
@@ -531,7 +531,7 @@ void* Dglobal_decodeURI(Dobject pthis, CallContext *cc, Dobject othis, Value* re
     catch(URIException u)
     {
         ret.putVundefined();
-        return URI_error(TEXT_decodeURI);
+        return URI_error(TEXT_decodeURI, cc);
     }
     ret.putVstring(s);
     return null;
@@ -542,7 +542,7 @@ void* Dglobal_decodeURIComponent(Dobject pthis, CallContext *cc, Dobject othis, 
     // ECMA v3 15.1.3.2
     d_string s;
 
-    s = arg0string(arglist);
+    s = arg0string(arglist, cc);
     try
     {
         s = std.uri.decodeComponent(s);
@@ -550,7 +550,7 @@ void* Dglobal_decodeURIComponent(Dobject pthis, CallContext *cc, Dobject othis, 
     catch(URIException u)
     {
         ret.putVundefined();
-        return URI_error(TEXT_decodeURIComponent);
+        return URI_error(TEXT_decodeURIComponent, cc);
     }
     ret.putVstring(s);
     return null;
@@ -561,7 +561,7 @@ void* Dglobal_encodeURI(Dobject pthis, CallContext *cc, Dobject othis, Value* re
     // ECMA v3 15.1.3.3
     d_string s;
 
-    s = arg0string(arglist);
+    s = arg0string(arglist, cc);
     try
     {
         s = std.uri.encode(s);
@@ -569,7 +569,7 @@ void* Dglobal_encodeURI(Dobject pthis, CallContext *cc, Dobject othis, Value* re
     catch(URIException u)
     {
         ret.putVundefined();
-        return URI_error(TEXT_encodeURI);
+        return URI_error(TEXT_encodeURI, cc);
     }
     ret.putVstring(s);
     return null;
@@ -580,7 +580,7 @@ void* Dglobal_encodeURIComponent(Dobject pthis, CallContext *cc, Dobject othis, 
     // ECMA v3 15.1.3.4
     d_string s;
 
-    s = arg0string(arglist);
+    s = arg0string(arglist, cc);
     try
     {
         s = std.uri.encodeComponent(s);
@@ -588,7 +588,7 @@ void* Dglobal_encodeURIComponent(Dobject pthis, CallContext *cc, Dobject othis, 
     catch(URIException u)
     {
         ret.putVundefined();
-        return URI_error(TEXT_encodeURIComponent);
+        return URI_error(TEXT_encodeURIComponent, cc);
     }
     ret.putVstring(s);
     return null;
@@ -605,7 +605,7 @@ static void dglobal_print(CallContext *cc, Dobject othis, Value* ret, Value[] ar
 
         for(i = 0; i < arglist.length; i++)
         {
-            d_string s = arglist[i].toString();
+            d_string s = arglist[i].toString(cc);
 
             writef("%s", s);
         }
@@ -689,7 +689,7 @@ void* Dglobal_getenv(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, 
     ret.putVundefined();
     if(arglist.length)
     {
-        d_string s = arglist[0].toString();
+        d_string s = arglist[0].toString(cc);
         char* p = getenv(toStringz(s));
         if(p)
             ret.putVstring(p[0 .. strlen(p)].idup);
@@ -730,9 +730,9 @@ void* Dglobal_ScriptEngineMinorVersion(Dobject pthis, CallContext *cc, Dobject o
 
 class Dglobal : Dobject
 {
-    this(tchar[][] argv)
+    this(CallContext* cc, tchar[][] argv)
     {
-        super(Dobject.getPrototype());  // Dglobal.prototype is implementation-dependent
+        super(cc, Dobject.getPrototype());  // Dglobal.prototype is implementation-dependent
 
         //writef("Dglobal.Dglobal(%x)\n", this);
 
@@ -745,9 +745,9 @@ class Dglobal : Dobject
 
         // Value properties
 
-        Put(TEXT_NaN, d_number.nan, DontEnum | DontDelete);
-        Put(TEXT_Infinity, d_number.infinity, DontEnum| DontDelete);
-		Put(TEXT_undefined, &vundefined, DontEnum| DontDelete);
+        Put(cc, TEXT_NaN, d_number.nan, DontEnum | DontDelete);
+        Put(cc, TEXT_Infinity, d_number.infinity, DontEnum| DontDelete);
+		Put(cc, TEXT_undefined, &vundefined, DontEnum| DontDelete);
         static enum NativeFunctionData[] nfd =
         [
             // Function properties
@@ -776,44 +776,44 @@ class Dglobal : Dobject
             { TEXT_ScriptEngineMinorVersion, &Dglobal_ScriptEngineMinorVersion, 0 },
         ];
 
-        DnativeFunction.initialize(this, nfd, DontEnum);
+        DnativeFunction.initialize(this, cc, nfd, DontEnum);
 
         // Now handled by AssertExp()
         // Put(TEXT_assert, Dglobal_assert(), DontEnum);
 
         // Constructor properties
 
-        Put(TEXT_Object, Dobject_constructor, DontEnum);
-        Put(TEXT_Function, Dfunction_constructor, DontEnum);
-        Put(TEXT_Array, Darray_constructor, DontEnum);
-        Put(TEXT_String, Dstring_constructor, DontEnum);
-        Put(TEXT_Boolean, Dboolean_constructor, DontEnum);
-        Put(TEXT_Number, Dnumber_constructor, DontEnum);
-        Put(TEXT_Date, Ddate_constructor, DontEnum);
-        Put(TEXT_RegExp, Dregexp_constructor, DontEnum);
-        Put(TEXT_Error, Derror_constructor, DontEnum);
+        Put(cc, TEXT_Object, Dobject_constructor, DontEnum);
+        Put(cc, TEXT_Function, Dfunction_constructor, DontEnum);
+        Put(cc, TEXT_Array, Darray_constructor, DontEnum);
+        Put(cc, TEXT_String, Dstring_constructor, DontEnum);
+        Put(cc, TEXT_Boolean, Dboolean_constructor, DontEnum);
+        Put(cc, TEXT_Number, Dnumber_constructor, DontEnum);
+        Put(cc, TEXT_Date, Ddate_constructor, DontEnum);
+        Put(cc, TEXT_RegExp, Dregexp_constructor, DontEnum);
+        Put(cc, TEXT_Error, Derror_constructor, DontEnum);
 
         foreach(d_string key, Dfunction ctor; ctorTable)
         {
-            Put(key, ctor, DontEnum);
+            Put(cc, key, ctor, DontEnum);
         }
 
         // Other properties
 
         assert(Dmath_object);
-        Put(TEXT_Math, Dmath_object, DontEnum);
+        Put(cc, TEXT_Math, Dmath_object, DontEnum);
 
         // Build an "arguments" property out of argv[],
         // and add it to the global object.
         Darray arguments;
 
-        arguments = new Darray();
-        Put(TEXT_arguments, arguments, DontDelete);
+        arguments = new Darray(cc);
+        Put(cc, TEXT_arguments, arguments, DontDelete);
         arguments.length.putVnumber(argv.length);
         for(int i = 0; i < argv.length; i++)
         {
-            arguments.Put(i, argv[i].idup, DontEnum);
+            arguments.Put(cc, i, argv[i].idup, DontEnum);
         }
-        arguments.Put(TEXT_callee, &vnull, DontEnum);
+        arguments.Put(cc, TEXT_callee, &vnull, DontEnum);
     }
 }

--- a/engine/source/dmdscript/dmath.d
+++ b/engine/source/dmdscript/dmath.d
@@ -28,12 +28,12 @@ import dmdscript.threadcontext;
 import dmdscript.text;
 import dmdscript.property;
 
-d_number math_helper(Value[] arglist)
+d_number math_helper(Value[] arglist, CallContext* cc)
 {
     Value *v;
 
     v = arglist.length ? &arglist[0] : &vundefined;
-    return v.toNumber();
+    return v.toNumber(cc);
 }
 
 void* Dmath_abs(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value[] arglist)
@@ -41,7 +41,7 @@ void* Dmath_abs(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     // ECMA 15.8.2.1
     d_number result;
 
-    result = fabs(math_helper(arglist));
+    result = fabs(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -51,7 +51,7 @@ void* Dmath_acos(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Valu
     // ECMA 15.8.2.2
     d_number result;
 
-    result = acos(math_helper(arglist));
+    result = acos(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -61,7 +61,7 @@ void* Dmath_asin(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Valu
     // ECMA 15.8.2.3
     d_number result;
 
-    result = asin(math_helper(arglist));
+    result = asin(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -71,7 +71,7 @@ void* Dmath_atan(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Valu
     // ECMA 15.8.2.4
     d_number result;
 
-    result = atan(math_helper(arglist));
+    result = atan(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -83,9 +83,9 @@ void* Dmath_atan2(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Val
     Value *v2;
     d_number result;
 
-    n1 = math_helper(arglist);
+    n1 = math_helper(arglist, cc);
     v2 = (arglist.length >= 2) ? &arglist[1] : &vundefined;
-    result = atan2(n1, v2.toNumber());
+    result = atan2(n1, v2.toNumber(cc));
     ret.putVnumber(result);
     return null;
 }
@@ -95,7 +95,7 @@ void* Dmath_ceil(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Valu
     // ECMA 15.8.2.6
     d_number result;
 
-    result = ceil(math_helper(arglist));
+    result = ceil(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -105,7 +105,7 @@ void* Dmath_cos(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     // ECMA 15.8.2.7
     d_number result;
 
-    result = cos(math_helper(arglist));
+    result = cos(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -115,7 +115,7 @@ void* Dmath_exp(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     // ECMA 15.8.2.8
     d_number result;
 
-    result = std.math.exp(math_helper(arglist));
+    result = std.math.exp(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -125,7 +125,7 @@ void* Dmath_floor(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Val
     // ECMA 15.8.2.9
     d_number result;
 
-    result = std.math.floor(math_helper(arglist));
+    result = std.math.floor(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -135,7 +135,7 @@ void* Dmath_log(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     // ECMA 15.8.2.10
     d_number result;
 
-    result = log(math_helper(arglist));
+    result = log(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -150,7 +150,7 @@ void* Dmath_max(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     result = -d_number.infinity;
     foreach(Value v; arglist)
     {
-        n = v.toNumber();
+        n = v.toNumber(cc);
         if(isNaN(n))
         {
             result = d_number.nan;
@@ -179,7 +179,7 @@ void* Dmath_min(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     result = d_number.infinity;
     foreach(Value v; arglist)
     {
-        n = v.toNumber();
+        n = v.toNumber(cc);
         if(isNaN(n))
         {
             result = d_number.nan;
@@ -205,9 +205,9 @@ void* Dmath_pow(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     Value *v2;
     d_number result;
 
-    n1 = math_helper(arglist);
+    n1 = math_helper(arglist, cc);
     v2 = (arglist.length >= 2) ? &arglist[1] : &vundefined;
-    result = pow(n1, v2.toNumber());
+    result = pow(n1, v2.toNumber(cc));
     ret.putVnumber(result);
     return null;
 }
@@ -245,7 +245,7 @@ void* Dmath_round(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Val
     // ECMA 15.8.2.15
     d_number result;
 
-    result = math_helper(arglist);
+    result = math_helper(arglist, cc);
     if(!isNaN(result))
         result = copysign(std.math.floor(result + .5), result);
     ret.putVnumber(result);
@@ -257,7 +257,7 @@ void* Dmath_sin(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     // ECMA 15.8.2.16
     d_number result;
 
-    result = sin(math_helper(arglist));
+    result = sin(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -267,7 +267,7 @@ void* Dmath_sqrt(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Valu
     // ECMA 15.8.2.17
     d_number result;
 
-    result = sqrt(math_helper(arglist));
+    result = sqrt(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -277,7 +277,7 @@ void* Dmath_tan(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
     // ECMA 15.8.2.18
     d_number result;
 
-    result = tan(math_helper(arglist));
+    result = tan(math_helper(arglist, cc));
     ret.putVnumber(result);
     return null;
 }
@@ -286,9 +286,9 @@ void* Dmath_tan(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Value
 
 class Dmath : Dobject
 {
-    this()
+    this(CallContext* cc)
     {
-        super(Dobject_prototype);
+        super(cc, Dobject_prototype);
 
         //writef("Dmath::Dmath(%x)\n", this);
         uint attributes = DontEnum | DontDelete | ReadOnly;
@@ -313,7 +313,7 @@ class Dmath : Dobject
         {
             Value *v;
 
-            v = Put(table[u].name, table[u].value, attributes);
+            v = Put(cc, table[u].name, table[u].value, attributes);
             //writef("Put(%s,%.5g) = %x\n", *table[u].name, table[u].value, v);
         }
 
@@ -341,12 +341,12 @@ class Dmath : Dobject
             { TEXT_tan, &Dmath_tan, 1 },
         ];
 
-        DnativeFunction.initialize(this, nfd, attributes);
+        DnativeFunction.initialize(this, cc, nfd, attributes);
     }
 
-    static void initialize()
+    static void initialize(CallContext* cc)
     {
-        Dmath_object = new Dmath();
+        Dmath_object = new Dmath(cc);
     }
 }
 

--- a/engine/source/dmdscript/dnative.d
+++ b/engine/source/dmdscript/dnative.d
@@ -38,16 +38,16 @@ class DnativeFunction : Dfunction
 {
     PCall pcall;
 
-    this(PCall func, d_string name, d_uint32 length)
+    this(CallContext* cc, PCall func, d_string name, d_uint32 length)
     {
-        super(length);
+        super(cc, length);
         this.name = name;
         pcall = func;
     }
 
-    this(PCall func, d_string name, d_uint32 length, Dobject o)
+    this(CallContext* cc, PCall func, d_string name, d_uint32 length, Dobject o)
     {
-        super(length, o);
+        super(cc, length, o);
         this.name = name;
         pcall = func;
     }
@@ -62,7 +62,7 @@ class DnativeFunction : Dfunction
      * to go in as properties of o.
      */
 
-    static void initialize(Dobject o, NativeFunctionData[] nfd, uint attributes)
+    static void initialize(Dobject o, CallContext* cc, NativeFunctionData[] nfd, uint attributes)
     {
         Dobject f = Dfunction.getPrototype();
 
@@ -70,8 +70,8 @@ class DnativeFunction : Dfunction
         {
             NativeFunctionData* n = &nfd[i];
 
-            o.Put(n.string,
-                  new DnativeFunction(n.pcall, n.string, n.length, f),
+            o.Put(cc, n.string,
+                  new DnativeFunction(cc, n.pcall, n.string, n.length, f),
                   attributes);
         }
     }

--- a/engine/source/dmdscript/dnumber.d
+++ b/engine/source/dmdscript/dnumber.d
@@ -35,17 +35,17 @@ import dmdscript.dnative;
 
 class DnumberConstructor : Dfunction
 {
-    this()
+    this(CallContext* cc)
     {
-        super(1, Dfunction_prototype);
+        super(cc, 1, Dfunction_prototype);
         uint attributes = DontEnum | DontDelete | ReadOnly;
 
         name = TEXT_Number;
-        Put(TEXT_MAX_VALUE, d_number.max, attributes);
-        Put(TEXT_MIN_VALUE, d_number.min_normal*d_number.epsilon, attributes);
-        Put(TEXT_NaN, d_number.nan, attributes);
-        Put(TEXT_NEGATIVE_INFINITY, -d_number.infinity, attributes);
-        Put(TEXT_POSITIVE_INFINITY, d_number.infinity, attributes);
+        Put(cc, TEXT_MAX_VALUE, d_number.max, attributes);
+        Put(cc, TEXT_MIN_VALUE, d_number.min_normal*d_number.epsilon, attributes);
+        Put(cc, TEXT_NaN, d_number.nan, attributes);
+        Put(cc, TEXT_NEGATIVE_INFINITY, -d_number.infinity, attributes);
+        Put(cc, TEXT_POSITIVE_INFINITY, d_number.infinity, attributes);
     }
 
     override void* Construct(CallContext *cc, Value *ret, Value[] arglist)
@@ -54,8 +54,8 @@ class DnumberConstructor : Dfunction
         d_number n;
         Dobject o;
 
-        n = (arglist.length) ? arglist[0].toNumber() : 0;
-        o = new Dnumber(n);
+        n = (arglist.length) ? arglist[0].toNumber(cc) : 0;
+        o = new Dnumber(cc, n);
         ret.putVobject(o);
         return null;
     }
@@ -65,7 +65,7 @@ class DnumberConstructor : Dfunction
         // ECMA 15.7.1
         d_number n;
 
-        n = (arglist.length) ? arglist[0].toNumber() : 0;
+        n = (arglist.length) ? arglist[0].toNumber(cc) : 0;
         ret.putVnumber(n);
         return null;
     }
@@ -85,6 +85,7 @@ void* Dnumber_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis, 
         ret.putVundefined();
         ErrInfo errinfo;
         return Dobject.RuntimeError(&errinfo,
+                                    cc,
                                     errmsgtbl[ERR_FUNCTION_WANTS_NUMBER],
                                     TEXT_toString,
                                     othis.classname);
@@ -99,9 +100,9 @@ void* Dnumber_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis, 
         {
             d_number radix;
 
-            radix = arglist[0].toNumber();
+            radix = arglist[0].toNumber(cc);
             if(radix == 10.0 || arglist[0].isUndefined())
-                s = v.toString();
+                s = v.toString(cc);
             else
             {
                 int r;
@@ -109,13 +110,13 @@ void* Dnumber_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis, 
                 r = cast(int)radix;
                 // radix must be an integer 2..36
                 if(r == radix && r >= 2 && r <= 36)
-                    s = v.toString(r);
+                    s = v.toString(cc, r);
                 else
-                    s = v.toString();
+                    s = v.toString(cc);
             }
         }
         else
-            s = v.toString();
+            s = v.toString(cc);
         ret.putVstring(s);
     }
     return null;
@@ -134,6 +135,7 @@ void* Dnumber_prototype_toLocaleString(Dobject pthis, CallContext *cc, Dobject o
         ret.putVundefined();
         ErrInfo errinfo;
         return Dobject.RuntimeError(&errinfo,
+                                    cc,
                                     errmsgtbl[ERR_FUNCTION_WANTS_NUMBER],
                                     TEXT_toLocaleString,
                                     othis.classname);
@@ -144,7 +146,7 @@ void* Dnumber_prototype_toLocaleString(Dobject pthis, CallContext *cc, Dobject o
 
         v = &(cast(Dnumber)othis).value;
 
-        s = v.toLocaleString();
+        s = v.toLocaleString(cc);
         ret.putVstring(s);
     }
     return null;
@@ -160,6 +162,7 @@ void* Dnumber_prototype_valueOf(Dobject pthis, CallContext *cc, Dobject othis, V
         ret.putVundefined();
         ErrInfo errinfo;
         return Dobject.RuntimeError(&errinfo,
+                                    cc,
                                     errmsgtbl[ERR_FUNCTION_WANTS_NUMBER],
                                     TEXT_valueOf,
                                     othis.classname);
@@ -231,7 +234,7 @@ void* Dnumber_prototype_toFixed(Dobject pthis, CallContext *cc, Dobject othis, V
     if(arglist.length)
 	{
 		v = &arglist[0];
-		fractionDigits =  v.toInteger();
+		fractionDigits =  v.toInteger(cc);
 	}
 	else
 		fractionDigits = 0;
@@ -240,11 +243,11 @@ void* Dnumber_prototype_toFixed(Dobject pthis, CallContext *cc, Dobject othis, V
         ErrInfo errinfo;
 
         ret.putVundefined();
-        return Dobject.RangeError(&errinfo, ERR_VALUE_OUT_OF_RANGE,
+        return Dobject.RangeError(&errinfo, cc, ERR_VALUE_OUT_OF_RANGE,
                                   TEXT_toFixed, "fractionDigits");
     }
     v = &othis.value;
-    x = v.toNumber();
+    x = v.toNumber(cc);
     if(isNaN(x))
     {
         result = TEXT_NaN;              // return "NaN"
@@ -264,7 +267,7 @@ void* Dnumber_prototype_toFixed(Dobject pthis, CallContext *cc, Dobject othis, V
         {
             Value vn;
             vn.putVnumber(x);
-            ret.putVstring(vn.toString());
+            ret.putVstring(vn.toString(cc));
             return null;
         }
         else
@@ -354,11 +357,11 @@ void* Dnumber_prototype_toExponential(Dobject pthis, CallContext *cc, Dobject ot
     if(arglist.length)
 	{
 		varg = &arglist[0];
-		fractionDigits = varg.toInteger();
+		fractionDigits = varg.toInteger(cc);
 	}else
 		fractionDigits = FIXED_DIGITS;
     v = &othis.value;
-    x = v.toNumber();
+    x = v.toNumber(cc);
     if(isNaN(x))
     {
         result = TEXT_NaN;              // return "NaN"
@@ -392,6 +395,7 @@ void* Dnumber_prototype_toExponential(Dobject pthis, CallContext *cc, Dobject ot
 
                 ret.putVundefined();
                 return Dobject.RangeError(&errinfo,
+                                          cc,
                                           ERR_VALUE_OUT_OF_RANGE,
                                           TEXT_toExponential,
                                           "fractionDigits");
@@ -491,7 +495,7 @@ void* Dnumber_prototype_toPrecision(Dobject pthis, CallContext *cc, Dobject othi
     d_string result;
 
     v = &othis.value;
-    x = v.toNumber();
+    x = v.toNumber(cc);
 
     varg = (arglist.length == 0) ? &vundefined : &arglist[0];
 
@@ -500,7 +504,7 @@ void* Dnumber_prototype_toPrecision(Dobject pthis, CallContext *cc, Dobject othi
         Value vn;
 
         vn.putVnumber(x);
-        result = vn.toString();
+        result = vn.toString(cc);
     }
     else
     {
@@ -529,13 +533,14 @@ void* Dnumber_prototype_toPrecision(Dobject pthis, CallContext *cc, Dobject othi
                 goto Ldone;
             }
 
-            precision = varg.toInteger();
+            precision = varg.toInteger(cc);
             if(precision < 1 || precision > 21)
             {
                 ErrInfo errinfo;
 
                 ret.putVundefined();
                 return Dobject.RangeError(&errinfo,
+                                          cc,
                                           ERR_VALUE_OUT_OF_RANGE,
                                           TEXT_toPrecision,
                                           "precision");
@@ -622,14 +627,14 @@ void* Dnumber_prototype_toPrecision(Dobject pthis, CallContext *cc, Dobject othi
 
 class DnumberPrototype : Dnumber
 {
-    this()
+    this(CallContext* cc)
     {
-        super(Dobject_prototype);
+        super(cc, Dobject_prototype);
         uint attributes = DontEnum;
 
         Dobject f = Dfunction_prototype;
 
-        Put(TEXT_constructor, Dnumber_constructor, attributes);
+        Put(cc, TEXT_constructor, Dnumber_constructor, attributes);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -642,7 +647,7 @@ class DnumberPrototype : Dnumber
             { TEXT_toPrecision, &Dnumber_prototype_toPrecision, 1 },
         ];
 
-        DnativeFunction.initialize(this, nfd, attributes);
+        DnativeFunction.initialize(this, cc, nfd, attributes);
     }
 }
 
@@ -651,16 +656,16 @@ class DnumberPrototype : Dnumber
 
 class Dnumber : Dobject
 {
-    this(d_number n)
+    this(CallContext* cc, d_number n)
     {
-        super(getPrototype());
+        super(cc, getPrototype());
         classname = TEXT_Number;
         value.putVnumber(n);
     }
 
-    this(Dobject prototype)
+    this(CallContext* cc, Dobject prototype)
     {
-        super(prototype);
+        super(cc, prototype);
         classname = TEXT_Number;
         value.putVnumber(0);
     }
@@ -675,12 +680,12 @@ class Dnumber : Dobject
         return Dnumber_prototype;
     }
 
-    static void initialize()
+    static void initialize(CallContext* cc)
     {
-        Dnumber_constructor = new DnumberConstructor();
-        Dnumber_prototype = new DnumberPrototype();
+        Dnumber_constructor = new DnumberConstructor(cc);
+        Dnumber_prototype = new DnumberPrototype(cc);
 
-        Dnumber_constructor.Put(TEXT_prototype, Dnumber_prototype, DontEnum | DontDelete | ReadOnly);
+        Dnumber_constructor.Put(cc, TEXT_prototype, Dnumber_prototype, DontEnum | DontDelete | ReadOnly);
     }
 }
 

--- a/engine/source/dmdscript/dobject.d
+++ b/engine/source/dmdscript/dobject.d
@@ -59,11 +59,11 @@ class ErrorValue: Exception {
 
 class DobjectConstructor : Dfunction
 {
-    this()
+    this(CallContext* cc)
     {
-        super(1, Dfunction_prototype);
+        super(cc, 1, Dfunction_prototype);
         if(Dobject_prototype)
-            Put(TEXT_prototype, Dobject_prototype, DontEnum | DontDelete | ReadOnly);
+            Put(cc, TEXT_prototype, Dobject_prototype, DontEnum | DontDelete | ReadOnly);
     }
 
     override void *Construct(CallContext *cc, Value *ret, Value[] arglist)
@@ -74,7 +74,7 @@ class DobjectConstructor : Dfunction
         // ECMA 15.2.2
         if(arglist.length == 0)
         {
-            o = new Dobject(Dobject.getPrototype());
+            o = new Dobject(cc, Dobject.getPrototype());
         }
         else
         {
@@ -83,13 +83,13 @@ class DobjectConstructor : Dfunction
             {
                 if(v.isUndefinedOrNull())
                 {
-                    o = new Dobject(Dobject.getPrototype());
+                    o = new Dobject(cc, Dobject.getPrototype());
                 }
                 else
-                    o = v.toObject();
+                    o = v.toObject(cc);
             }
             else
-                o = v.toObject();
+                o = v.toObject(cc);
         }
         //printf("constructed object o=%p, v=%p,'%s'\n", o, v,v.getType());
         ret.putVobject(o);
@@ -115,7 +115,7 @@ class DobjectConstructor : Dfunction
                 result = Construct(cc, ret, arglist);
             else
             {
-                o = v.toObject();
+                o = v.toObject(cc);
                 ret.putVobject(o);
                 result = null;
             }
@@ -196,9 +196,9 @@ void* Dobject_prototype_toSource(Dobject pthis, CallContext *cc, Dobject othis, 
             if(any)
                 buf ~= ',';
             any = 1;
-            buf ~= key.toString();
+            buf ~= key.toString(cc);
             buf ~= ':';
-            buf ~= p.value.toSource();
+            buf ~= p.value.toSource(cc);
         }
     }
     buf ~= '}';
@@ -230,7 +230,7 @@ void* Dobject_prototype_isPrototypeOf(Dobject pthis, CallContext *cc, Dobject ot
     v = arglist.length ? &arglist[0] : &vundefined;
     if(!v.isPrimitive())
     {
-        o = v.toObject();
+        o = v.toObject(cc);
         for(;; )
         {
             o = o.internal_prototype;
@@ -264,9 +264,9 @@ void* Dobject_prototype_propertyIsEnumerable(Dobject pthis, CallContext *cc, Dob
 
 class DobjectPrototype : Dobject
 {
-    this()
+    this(CallContext* cc)
     {
-        super(null);
+        super(cc, null);
     }
 }
 
@@ -288,11 +288,11 @@ class Dobject
         assert(signature == DOBJECT_SIGNATURE);
     }
 
-    this(Dobject prototype)
+    this(CallContext* cc, Dobject prototype)
     {
         //writef("new Dobject = %x, prototype = %x, line = %d, file = '%s'\n", this, prototype, GC.line, ascii2unicode(GC.file));
         //writef("Dobject(prototype = %p)\n", prototype);
-        proptable = new PropTable;
+        proptable = new PropTable(cc);
         internal_prototype = prototype;
         if(prototype)
             proptable.previous = prototype.proptable;
@@ -351,7 +351,7 @@ class Dobject
         return proptable.get(vindex, Value.calcHash(index));
     }
 
-    Value* Put(d_string PropertyName, Value* value, uint attributes)
+    Value* Put(CallContext* cc, d_string PropertyName, Value* value, uint attributes)
     {
         // ECMA 8.6.2.2
         //writef("Dobject.Put(this = %p)\n", this);
@@ -359,7 +359,7 @@ class Dobject
         return null;
     }
 
-    Value* Put(Identifier* key, Value* value, uint attributes)
+    Value* Put(CallContext* cc, Identifier* key, Value* value, uint attributes)
     {
         // ECMA 8.6.2.2
         //writef("Dobject.Put(this = %p)\n", this);
@@ -367,7 +367,7 @@ class Dobject
         return null;
     }
 
-    Value* Put(d_string PropertyName, Dobject o, uint attributes)
+    Value* Put(CallContext* cc, d_string PropertyName, Dobject o, uint attributes)
     {
         // ECMA 8.6.2.2
         Value v;
@@ -377,7 +377,7 @@ class Dobject
         return null;
     }
 
-    Value* Put(d_string PropertyName, d_number n, uint attributes)
+    Value* Put(CallContext* cc, d_string PropertyName, d_number n, uint attributes)
     {
         // ECMA 8.6.2.2
         Value v;
@@ -387,7 +387,7 @@ class Dobject
         return null;
     }
 
-    Value* Put(d_string PropertyName, d_string s, uint attributes)
+    Value* Put(CallContext* cc, d_string PropertyName, d_string s, uint attributes)
     {
         // ECMA 8.6.2.2
         Value v;
@@ -397,34 +397,34 @@ class Dobject
         return null;
     }
 
-    Value* Put(d_uint32 index, Value* vindex, Value* value, uint attributes)
+    Value* Put(CallContext* cc, d_uint32 index, Value* vindex, Value* value, uint attributes)
     {
         // ECMA 8.6.2.2
         proptable.put(vindex, Value.calcHash(index), value, attributes);
         return null;
     }
 
-    Value* Put(d_uint32 index, Value* value, uint attributes)
+    Value* Put(CallContext* cc, d_uint32 index, Value* value, uint attributes)
     {
         // ECMA 8.6.2.2
         proptable.put(index, value, attributes);
         return null;
     }
 
-    Value* PutDefault(Value* value)
+    Value* PutDefault(CallContext* cc, Value* value)
     {
         // Not ECMA, Microsoft extension
         //writef("Dobject.PutDefault(this = %p)\n", this);
         ErrInfo errinfo;
-        return RuntimeError(&errinfo, ERR_NO_DEFAULT_PUT);
+        return RuntimeError(&errinfo, cc, ERR_NO_DEFAULT_PUT);
     }
 
-    Value* put_Value(Value* ret, Value[] arglist)
+    Value* put_Value(CallContext* cc, Value* ret, Value[] arglist)
     {
         // Not ECMA, Microsoft extension
         //writef("Dobject.put_Value(this = %p)\n", this);
         ErrInfo errinfo;
-        return RuntimeError(&errinfo, ERR_FUNCTION_NOT_LVALUE);
+        return RuntimeError(&errinfo, cc, ERR_FUNCTION_NOT_LVALUE);
     }
 
     int CanPut(d_string PropertyName)
@@ -466,7 +466,7 @@ class Dobject
         return true;
     }
 
-    void *DefaultValue(Value* ret, d_string Hint)
+    void *DefaultValue(CallContext* cc, Value* ret, d_string Hint)
     {
         Dobject o;
         Value* v;
@@ -499,11 +499,9 @@ class Dobject
             if(v && !v.isPrimitive())   // if it's an Object
             {
                 void *a;
-                CallContext *cc;
 
                 //writefln("\tfound default value");
                 o = v.object;
-                cc = Program.getProgram().callcontext;
                 a = o.Call(cc, this, ret, null);
                 if(a)                   // if exception was thrown
                     return a;
@@ -513,7 +511,7 @@ class Dobject
             i ^= 1;
         }
         ErrInfo errinfo;
-        return Dobject.RuntimeError(&errinfo, "No [[DefaultValue]]");
+        return Dobject.RuntimeError(&errinfo, cc, "No [[DefaultValue]]");
         //ErrInfo errinfo;
         //return RuntimeError(&errinfo, DTEXT("no Default Value for object"));
     }
@@ -521,19 +519,19 @@ class Dobject
     void *Construct(CallContext *cc, Value *ret, Value[] arglist)
     {
         ErrInfo errinfo;
-        return RuntimeError(&errinfo, errmsgtbl[ERR_S_NO_CONSTRUCT], classname);
+        return RuntimeError(&errinfo, cc, errmsgtbl[ERR_S_NO_CONSTRUCT], classname);
     }
 
     void *Call(CallContext *cc, Dobject othis, Value* ret, Value[] arglist)
     {
         ErrInfo errinfo;
-        return RuntimeError(&errinfo, errmsgtbl[ERR_S_NO_CALL], classname);
+        return RuntimeError(&errinfo, cc, errmsgtbl[ERR_S_NO_CALL], classname);
     }
 
-    void *HasInstance(Value* ret, Value* v)
+    void *HasInstance(CallContext* cc, Value* ret, Value* v)
     {   // ECMA v3 8.6.2
         ErrInfo errinfo;
-        return RuntimeError(&errinfo, errmsgtbl[ERR_S_NO_INSTANCE], classname);
+        return RuntimeError(&errinfo, cc, errmsgtbl[ERR_S_NO_INSTANCE], classname);
     }
 
     d_string getTypeof()
@@ -573,23 +571,23 @@ class Dobject
         return false;
     }
 
-    void getErrInfo(ErrInfo *perrinfo, int linnum)
+    void getErrInfo(CallContext* cc, ErrInfo *perrinfo, int linnum)
     {
         ErrInfo errinfo;
         Value v;
         v.putVobject(this);
 
-        errinfo.message = v.toString();
+        errinfo.message = v.toString(cc);
         if(perrinfo)
             *perrinfo = errinfo;
     }
 
-    static Value* RuntimeError(ARGS...)(ErrInfo *perrinfo, int msgnum, ARGS args)
+    static Value* RuntimeError(ARGS...)(ErrInfo *perrinfo, CallContext* cc, int msgnum, ARGS args)
     {
-        return RuntimeError(perrinfo, errmsgtbl[msgnum], args);
+        return RuntimeError(perrinfo, cc, errmsgtbl[msgnum], args);
     }
 
-    static Value* RuntimeError(ARGS...)(ErrInfo *perrinfo, string fmt, ARGS args)
+    static Value* RuntimeError(ARGS...)(ErrInfo *perrinfo, CallContext* cc, string fmt, ARGS args)
     {
         import std.format : formattedWrite;
 
@@ -605,23 +603,23 @@ class Dobject
 
         formattedWrite(&putc, fmt, args);
         perrinfo.message = assumeUnique(buffer);
-        o = new typeerror.D0(perrinfo);
+        o = new typeerror.D0(cc, perrinfo);
         Value* v = new Value;
         v.putVobject(o);
         return v;
     }
-    static Value* ReferenceError(ARGS...)(ErrInfo *perrinfo, int msgnum, ARGS args)
+    static Value* ReferenceError(ARGS...)(ErrInfo *perrinfo, CallContext* cc, int msgnum, ARGS args)
     {
-        return ReferenceError(perrinfo, errmsgtbl[msgnum], args);
+        return ReferenceError(perrinfo, cc, errmsgtbl[msgnum], args);
     }
 
-    static Value* ReferenceError(ARGS...)(string fmt, ARGS args)
+    static Value* ReferenceError(ARGS...)(CallContext* cc, string fmt, ARGS args)
     {
         ErrInfo errinfo;
-        return ReferenceError(&errinfo, fmt, args);
+        return ReferenceError(&errinfo, cc, fmt, args);
     }
 
-    static Value* ReferenceError(ARGS...)(ErrInfo* perrinfo, string fmt, ARGS args)
+    static Value* ReferenceError(ARGS...)(ErrInfo* perrinfo, CallContext* cc, string fmt, ARGS args)
     {
         import std.format : formattedWrite;
 
@@ -637,18 +635,18 @@ class Dobject
         formattedWrite(&putc, fmt, args);
         perrinfo.message = buffer;
 
-        o = new referenceerror.D0(perrinfo);
+        o = new referenceerror.D0(cc, perrinfo);
         Value* v = new Value;
         v.putVobject(o);
 
         return v;
     }
-    static Value* RangeError(ARGS...)(ErrInfo *perrinfo, int msgnum, ARGS args)
+    static Value* RangeError(ARGS...)(ErrInfo *perrinfo, CallContext* cc, int msgnum, ARGS args)
     {
-        return RangeError(perrinfo, errmsgtbl[msgnum], args);
+        return RangeError(perrinfo, cc, errmsgtbl[msgnum], args);
     }
 
-    static Value* RangeError(ARGS...)(ErrInfo *perrinfo, string fmt, ARGS args)
+    static Value* RangeError(ARGS...)(ErrInfo *perrinfo, CallContext* cc, string fmt, ARGS args)
     {
         import std.format : formattedWrite;
 
@@ -665,17 +663,17 @@ class Dobject
         formattedWrite(&putc, fmt, args);
         perrinfo.message = buffer;
 
-        o = new rangeerror.D0(perrinfo);
+        o = new rangeerror.D0(cc, perrinfo);
         Value* v = new Value;
         v.putVobject(o);
         return v;
     }
 
-    Value* putIterator(Value* v)
+    Value* putIterator(CallContext* cc, Value* v)
     {
         Iterator* i = new Iterator;
 
-        i.ctor(this);
+        i.ctor(cc, this);
         v.putViterator(i);
         return null;
     }
@@ -690,16 +688,16 @@ class Dobject
         return Dobject_prototype;
     }
 
-    static void initialize()
+    static void initialize(CallContext* cc)
     {
-        Dobject_prototype = new DobjectPrototype();
-        Dfunction.initialize();
-        Dobject_constructor = new DobjectConstructor();
+        Dobject_prototype = new DobjectPrototype(cc);
+        Dfunction.initialize(cc);
+        Dobject_constructor = new DobjectConstructor(cc);
 
         Dobject op = Dobject_prototype;
         Dobject f = Dfunction_prototype;
 
-        op.Put(TEXT_constructor, Dobject_constructor, DontEnum);
+        op.Put(cc, TEXT_constructor, Dobject_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -712,7 +710,7 @@ class Dobject
             { TEXT_propertyIsEnumerable, &Dobject_prototype_propertyIsEnumerable, 0 },
         ];
 
-        DnativeFunction.initialize(op, nfd, DontEnum);
+        DnativeFunction.initialize(op, cc, nfd, DontEnum);
     }
 }
 
@@ -721,7 +719,7 @@ class Dobject
  * Initialize the built-in's.
  */
 
-void dobject_init()
+void dobject_init(CallContext* cc)
 {
     //writef("dobject_init(tc = %x)\n", cast(uint)tc);
     if(Dobject_prototype)
@@ -737,19 +735,19 @@ void dobject_init()
         writef("offsetof(value) = %d\n", offsetof(Dobject, value));
     }
 
-    Dobject.initialize();
-    Dboolean.initialize();
-    Dstring.initialize();
-    Dnumber.initialize();
-    Darray.initialize();
-    Dmath.initialize();
-    Ddate.initialize();
-    Dregexp.initialize();
-    Derror.initialize();
+    Dobject.initialize(cc);
+    Dboolean.initialize(cc);
+    Dstring.initialize(cc);
+    Dnumber.initialize(cc);
+    Darray.initialize(cc);
+    Dmath.initialize(cc);
+    Ddate.initialize(cc);
+    Dregexp.initialize(cc);
+    Derror.initialize(cc);
 	
 	// Call registered initializer for each object type
-    foreach(void function() fpinit; threadInitTable)
-        (*fpinit)();
+    foreach(fpinit; threadInitTable)
+        fpinit(cc);
 	
 }
 /*Not used anyway

--- a/engine/source/dmdscript/dregexp.d
+++ b/engine/source/dmdscript/dregexp.d
@@ -54,9 +54,9 @@ class DregexpConstructor : Dfunction
     Value* index;
     Value* lastIndex;
 
-    this()
+    this(CallContext* cc)
     {
-        super(2, Dfunction_prototype);
+        super(cc, 2, Dfunction_prototype);
 
         Value v;
         v.putVstring(null);
@@ -70,24 +70,24 @@ class DregexpConstructor : Dfunction
         name = "RegExp";
 
         // Static properties
-        Put(TEXT_input, &v, DontDelete);
-        Put(TEXT_multiline, &vb, DontDelete);
-        Put(TEXT_lastMatch, &v, ReadOnly | DontDelete);
-        Put(TEXT_lastParen, &v, ReadOnly | DontDelete);
-        Put(TEXT_leftContext, &v, ReadOnly | DontDelete);
-        Put(TEXT_rightContext, &v, ReadOnly | DontDelete);
-        Put(TEXT_dollar1, &v, ReadOnly | DontDelete);
-        Put(TEXT_dollar2, &v, ReadOnly | DontDelete);
-        Put(TEXT_dollar3, &v, ReadOnly | DontDelete);
-        Put(TEXT_dollar4, &v, ReadOnly | DontDelete);
-        Put(TEXT_dollar5, &v, ReadOnly | DontDelete);
-        Put(TEXT_dollar6, &v, ReadOnly | DontDelete);
-        Put(TEXT_dollar7, &v, ReadOnly | DontDelete);
-        Put(TEXT_dollar8, &v, ReadOnly | DontDelete);
-        Put(TEXT_dollar9, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_input, &v, DontDelete);
+        Put(cc, TEXT_multiline, &vb, DontDelete);
+        Put(cc, TEXT_lastMatch, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_lastParen, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_leftContext, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_rightContext, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_dollar1, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_dollar2, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_dollar3, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_dollar4, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_dollar5, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_dollar6, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_dollar7, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_dollar8, &v, ReadOnly | DontDelete);
+        Put(cc, TEXT_dollar9, &v, ReadOnly | DontDelete);
 
-        Put(TEXT_index, &vnm1, ReadOnly | DontDelete);
-        Put(TEXT_lastIndex, &vnm1, ReadOnly | DontDelete);
+        Put(cc, TEXT_index, &vnm1, ReadOnly | DontDelete);
+        Put(cc, TEXT_lastIndex, &vnm1, ReadOnly | DontDelete);
 
         input = Get(TEXT_input);
         multiline = Get(TEXT_multiline);
@@ -143,7 +143,7 @@ class DregexpConstructor : Dfunction
             pattern = &arglist[0];
             break;
         }
-        R = Dregexp.isRegExp(pattern);
+        R = Dregexp.isRegExp(pattern, cc);
         if(R)
         {
             if(flags.isUndefined())
@@ -154,16 +154,16 @@ class DregexpConstructor : Dfunction
             else
             {
                 ErrInfo errinfo;
-                return RuntimeError(&errinfo, ERR_TYPE_ERROR,
+                return RuntimeError(&errinfo, cc, ERR_TYPE_ERROR,
                                     "RegExp.prototype.constructor");
             }
         }
         else
         {
-            P = pattern.isUndefined() ? "" : pattern.toString();
-            F = flags.isUndefined() ? "" : flags.toString();
+            P = pattern.isUndefined() ? "" : pattern.toString(cc);
+            F = flags.isUndefined() ? "" : flags.toString(cc);
         }
-        r = new Dregexp(P, F);
+        r = new Dregexp(cc, P, F);
         if(r.re.errors)
         {
             Dobject o;
@@ -176,7 +176,7 @@ class DregexpConstructor : Dfunction
                     writef("x%02x\n", d_string_ptr(P)[i]);
             }
             errinfo.message = errmsgtbl[ERR_REGEXP_COMPILE];
-            o = new syntaxerror.D0(&errinfo);
+            o = new syntaxerror.D0(cc, &errinfo);
             Value* v = new Value;
             v.putVobject(o);
             return v;
@@ -218,19 +218,19 @@ class DregexpConstructor : Dfunction
         return Dfunction.Get(perlAlias(PropertyName));
     }
 
-    override Value* Put(d_string PropertyName, Value* value, uint attributes)
+    override Value* Put(CallContext* cc, d_string PropertyName, Value* value, uint attributes)
     {
-        return Dfunction.Put(perlAlias(PropertyName), value, attributes);
+        return Dfunction.Put(cc, perlAlias(PropertyName), value, attributes);
     }
 
-    override Value* Put(d_string PropertyName, Dobject o, uint attributes)
+    override Value* Put(CallContext* cc, d_string PropertyName, Dobject o, uint attributes)
     {
-        return Dfunction.Put(perlAlias(PropertyName), o, attributes);
+        return Dfunction.Put(cc, perlAlias(PropertyName), o, attributes);
     }
 
-    override Value* Put(d_string PropertyName, d_number n, uint attributes)
+    override Value* Put(CallContext* cc, d_string PropertyName, d_number n, uint attributes)
     {
-        return Dfunction.Put(perlAlias(PropertyName), n, attributes);
+        return Dfunction.Put(cc, perlAlias(PropertyName), n, attributes);
     }
 
     override int CanPut(d_string PropertyName)
@@ -291,7 +291,7 @@ void* Dregexp_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis, 
     {
         ret.putVundefined();
         ErrInfo errinfo;
-        return Dobject.RuntimeError(&errinfo, ERR_NOT_TRANSFERRABLE,
+        return Dobject.RuntimeError(&errinfo, cc, ERR_NOT_TRANSFERRABLE,
                                     "RegExp.prototype.toString()");
     }
     else
@@ -314,14 +314,14 @@ void* Dregexp_prototype_test(Dobject pthis, CallContext *cc, Dobject othis, Valu
 {
     // ECMA v3 15.10.6.3 says this is equivalent to:
     //	RegExp.prototype.exec(string) != null
-    return Dregexp.exec(othis, ret, arglist, EXEC_BOOLEAN);
+    return Dregexp.exec(othis, cc, ret, arglist, EXEC_BOOLEAN);
 }
 
 /* ===================== Dregexp_prototype_exec ============= */
 
 void* Dregexp_prototype_exec(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return Dregexp.exec(othis, ret, arglist, EXEC_ARRAY);
+    return Dregexp.exec(othis, cc, ret, arglist, EXEC_ARRAY);
 }
 
 
@@ -336,7 +336,7 @@ void* Dregexp_prototype_compile(Dobject pthis, CallContext *cc, Dobject othis, V
     {
         ErrInfo errinfo;
         ret.putVundefined();
-        return Dobject.RuntimeError(&errinfo, ERR_NOT_TRANSFERRABLE,
+        return Dobject.RuntimeError(&errinfo, cc, ERR_NOT_TRANSFERRABLE,
                                     "RegExp.prototype.compile()");
     }
     else
@@ -353,10 +353,10 @@ void* Dregexp_prototype_compile(Dobject pthis, CallContext *cc, Dobject othis, V
             break;
 
         default:
-            attributes = arglist[1].toString();
+            attributes = arglist[1].toString(cc);
             goto case;
         case 1:
-            pattern = arglist[0].toString();
+            pattern = arglist[0].toString(cc);
             break;
         }
 
@@ -384,14 +384,14 @@ void* Dregexp_prototype_compile(Dobject pthis, CallContext *cc, Dobject othis, V
 
 class DregexpPrototype : Dregexp
 {
-    this()
+    this(CallContext* cc)
     {
-        super(Dobject_prototype);
+        super(cc, Dobject_prototype);
         classname = TEXT_Object;
         uint attributes = ReadOnly | DontDelete | DontEnum;
         Dobject f = Dfunction_prototype;
 
-        Put(TEXT_constructor, Dregexp_constructor, attributes);
+        Put(cc, TEXT_constructor, Dregexp_constructor, attributes);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -401,7 +401,7 @@ class DregexpPrototype : Dregexp
             { TEXT_test, &Dregexp_prototype_test, 1 },
         ];
 
-        DnativeFunction.initialize(this, nfd, attributes);
+        DnativeFunction.initialize(this, cc, nfd, attributes);
     }
 }
 
@@ -419,9 +419,9 @@ class Dregexp : Dobject
 
     RegExp re;
 
-    this(d_string pattern, d_string attributes)
+    this(CallContext* cc, d_string pattern, d_string attributes)
     {
-        super(getPrototype());
+        super(cc, getPrototype());
 
         Value v;
         v.putVstring(null);
@@ -432,11 +432,11 @@ class Dregexp : Dobject
         classname = TEXT_RegExp;
 
         //writef("Dregexp.Dregexp(pattern = '%ls', attributes = '%ls')\n", d_string_ptr(pattern), d_string_ptr(attributes));
-        Put(TEXT_source, &v, ReadOnly | DontDelete | DontEnum);
-        Put(TEXT_global, &vb, ReadOnly | DontDelete | DontEnum);
-        Put(TEXT_ignoreCase, &vb, ReadOnly | DontDelete | DontEnum);
-        Put(TEXT_multiline, &vb, ReadOnly | DontDelete | DontEnum);
-        Put(TEXT_lastIndex, 0.0, DontDelete | DontEnum);
+        Put(cc, TEXT_source, &v, ReadOnly | DontDelete | DontEnum);
+        Put(cc, TEXT_global, &vb, ReadOnly | DontDelete | DontEnum);
+        Put(cc, TEXT_ignoreCase, &vb, ReadOnly | DontDelete | DontEnum);
+        Put(cc, TEXT_multiline, &vb, ReadOnly | DontDelete | DontEnum);
+        Put(cc, TEXT_lastIndex, 0.0, DontDelete | DontEnum);
 
         source = Get(TEXT_source);
         global = Get(TEXT_global);
@@ -459,9 +459,9 @@ class Dregexp : Dobject
         }
     }
 
-    this(Dobject prototype)
+    this(CallContext* cc, Dobject prototype)
     {
-        super(prototype);
+        super(cc, prototype);
 
         Value v;
         v.putVstring(null);
@@ -471,11 +471,11 @@ class Dregexp : Dobject
 
         classname = TEXT_RegExp;
 
-        Put(TEXT_source, &v, ReadOnly | DontDelete | DontEnum);
-        Put(TEXT_global, &vb, ReadOnly | DontDelete | DontEnum);
-        Put(TEXT_ignoreCase, &vb, ReadOnly | DontDelete | DontEnum);
-        Put(TEXT_multiline, &vb, ReadOnly | DontDelete | DontEnum);
-        Put(TEXT_lastIndex, 0.0, DontDelete | DontEnum);
+        Put(cc, TEXT_source, &v, ReadOnly | DontDelete | DontEnum);
+        Put(cc, TEXT_global, &vb, ReadOnly | DontDelete | DontEnum);
+        Put(cc, TEXT_ignoreCase, &vb, ReadOnly | DontDelete | DontEnum);
+        Put(cc, TEXT_multiline, &vb, ReadOnly | DontDelete | DontEnum);
+        Put(cc, TEXT_lastIndex, 0.0, DontDelete | DontEnum);
 
         source = Get(TEXT_source);
         global = Get(TEXT_global);
@@ -492,21 +492,21 @@ class Dregexp : Dobject
         Value* v;
 
         v = Get(TEXT_exec);
-        return v.toObject().Call(cc, this, ret, arglist);
+        return v.toObject(cc).Call(cc, this, ret, arglist);
     }
 
-    static Dregexp isRegExp(Value* v)
+    static Dregexp isRegExp(Value* v, CallContext* cc)
     {
         Dregexp r;
 
-        if(!v.isPrimitive() && v.toObject().isDregexp())
+        if(!v.isPrimitive() && v.toObject(cc).isDregexp())
         {
-            r = cast(Dregexp)(v.toObject());
+            r = cast(Dregexp)(v.toObject(cc));
         }
         return r;
     }
 
-    static void* exec(Dobject othis, Value* ret, Value[] arglist, int rettype)
+    static void* exec(Dobject othis, CallContext* cc, Value* ret, Value[] arglist, int rettype)
     {
         //writef("Dregexp.exec(arglist.length = %d, rettype = %d)\n", arglist.length, rettype);
 
@@ -515,7 +515,7 @@ class Dregexp : Dobject
         {
             ret.putVundefined();
             ErrInfo errinfo;
-            return RuntimeError(&errinfo, ERR_NOT_TRANSFERRABLE,
+            return RuntimeError(&errinfo, cc, ERR_NOT_TRANSFERRABLE,
                                 "RegExp.prototype.exec()");
         }
         else
@@ -528,7 +528,7 @@ class Dregexp : Dobject
             d_int32 lasti;
 
             if(arglist.length)
-                s = arglist[0].toString();
+                s = arglist[0].toString(cc);
             else
             {
                 Dfunction df;
@@ -548,7 +548,7 @@ class Dregexp : Dobject
                 r.attributes &= ~RegExp.REA.multiline;
 
             if(r.attributes & RegExp.REA.global && rettype != EXEC_INDEX)
-                lasti = cast(int)dr.lastIndex.toInteger();
+                lasti = cast(int)dr.lastIndex.toInteger(cc);
             else
                 lasti = 0;
 
@@ -613,33 +613,33 @@ class Dregexp : Dobject
                 {
                 case EXEC_ARRAY:
                 {
-                    Darray a = new Darray();
+                    Darray a = new Darray(cc);
 
-                    a.Put(TEXT_input, r.input, 0);
-                    a.Put(TEXT_index, r.pmatch[0].rm_so, 0);
-                    a.Put(TEXT_lastIndex, r.pmatch[0].rm_eo, 0);
+                    a.Put(cc, TEXT_input, r.input, 0);
+                    a.Put(cc, TEXT_index, r.pmatch[0].rm_so, 0);
+                    a.Put(cc, TEXT_lastIndex, r.pmatch[0].rm_eo, 0);
 
-                    a.Put(cast(d_uint32)0, dc.lastMatch, cast(uint)0);
+                    a.Put(cc, cast(d_uint32)0, dc.lastMatch, cast(uint)0);
 
                     // [1]..[nparens]
                     for(i = 1; i <= r.re_nsub; i++)
                     {
                         if(i > nmatches)
-                            a.Put(i, TEXT_, 0);
+                            a.Put(cc, i, TEXT_, 0);
 
                         // Reuse values already put into dc.dollar[]
                         else if(r.re_nsub <= 9)
-                            a.Put(i, dc.dollar[i], 0);
+                            a.Put(cc, i, dc.dollar[i], 0);
                         else if(i > r.re_nsub - 9)
-                            a.Put(i, dc.dollar[i - (r.re_nsub - 9)], 0);
+                            a.Put(cc, i, dc.dollar[i - (r.re_nsub - 9)], 0);
                         else if(r.pmatch[i].rm_so == -1)
                         {
-                            a.Put(i, &vundefined, 0);
+                            a.Put(cc, i, &vundefined, 0);
                         }
                         else
                         {
                             s = r.input[r.pmatch[i].rm_so .. r.pmatch[i].rm_eo];
-                            a.Put(i, s, 0);
+                            a.Put(cc, i, s, 0);
                         }
                     }
                     ret.putVobject(a);
@@ -705,10 +705,10 @@ class Dregexp : Dobject
         return Dregexp_prototype;
     }
 
-    static void initialize()
+    static void initialize(CallContext* cc)
     {
-        Dregexp_constructor = new DregexpConstructor();
-        Dregexp_prototype = new DregexpPrototype();
+        Dregexp_constructor = new DregexpConstructor(cc);
+        Dregexp_prototype = new DregexpPrototype(cc);
 
         version(none)
         {
@@ -720,6 +720,6 @@ class Dregexp : Dobject
                 writef("*p = %x, %x, %x, %x\n", p[0], p[1], p[2], p[3]);
         }
 
-        Dregexp_constructor.Put(TEXT_prototype, Dregexp_prototype, DontEnum | DontDelete | ReadOnly);
+        Dregexp_constructor.Put(cc, TEXT_prototype, Dregexp_prototype, DontEnum | DontDelete | ReadOnly);
     }
 }

--- a/engine/source/dmdscript/dstring.d
+++ b/engine/source/dmdscript/dstring.d
@@ -56,7 +56,7 @@ void* Dstring_fromCharCode(Dobject pthis, CallContext *cc, Dobject othis, Value 
         uint u;
 
         v = &arglist[i];
-        u = v.toUint16();
+        u = v.toUint16(cc);
         //writef("string.fromCharCode(%x)", u);
         if(!std.utf.isValidDchar(u))
         {
@@ -64,6 +64,7 @@ void* Dstring_fromCharCode(Dobject pthis, CallContext *cc, Dobject othis, Value 
 
             ret.putVundefined();
             return pthis.RuntimeError(&errinfo,
+                                      cc,
                                       errmsgtbl[ERR_NOT_VALID_UTF],
                                       "String", "fromCharCode()",
                                       u);
@@ -79,9 +80,9 @@ void* Dstring_fromCharCode(Dobject pthis, CallContext *cc, Dobject othis, Value 
 
 class DstringConstructor : Dfunction
 {
-    this()
+    this(CallContext* cc)
     {
-        super(1, Dfunction_prototype);
+        super(cc, 1, Dfunction_prototype);
         name = "String";
 
         static enum NativeFunctionData[] nfd =
@@ -89,7 +90,7 @@ class DstringConstructor : Dfunction
             { TEXT_fromCharCode, &Dstring_fromCharCode, 1 },
         ];
 
-        DnativeFunction.initialize(this, nfd, 0);
+        DnativeFunction.initialize(this, cc, nfd, 0);
     }
 
     override void *Construct(CallContext *cc, Value *ret, Value[] arglist)
@@ -98,8 +99,8 @@ class DstringConstructor : Dfunction
         d_string s;
         Dobject o;
 
-        s = (arglist.length) ? arglist[0].toString() : TEXT_;
-        o = new Dstring(s);
+        s = (arglist.length) ? arglist[0].toString(cc) : TEXT_;
+        o = new Dstring(cc, s);
         ret.putVobject(o);
         return null;
     }
@@ -109,7 +110,7 @@ class DstringConstructor : Dfunction
         // ECMA 15.5.1
         d_string s;
 
-        s = (arglist.length) ? arglist[0].toString() : TEXT_;
+        s = (arglist.length) ? arglist[0].toString(cc) : TEXT_;
         ret.putVstring(s);
         return null;
     }
@@ -128,6 +129,7 @@ void* Dstring_prototype_toString(Dobject pthis, CallContext *cc, Dobject othis, 
 
         ret.putVundefined();
         return pthis.RuntimeError(&errinfo,
+                                  cc,
                                   errmsgtbl[ERR_FUNCTION_WANTS_STRING],
                                   TEXT_toString,
                                   othis.classname);
@@ -156,6 +158,7 @@ void* Dstring_prototype_valueOf(Dobject pthis, CallContext *cc, Dobject othis, V
 
         ret.putVundefined();
         return pthis.RuntimeError(&errinfo,
+                                  cc,
                                   errmsgtbl[ERR_FUNCTION_WANTS_STRING],
                                   TEXT_valueOf,
                                   othis.classname);
@@ -183,9 +186,9 @@ void* Dstring_prototype_charAt(Dobject pthis, CallContext *cc, Dobject othis, Va
     d_string result;
 
     v = &othis.value;
-    s = v.toString();
+    s = v.toString(cc);
     v = arglist.length ? &arglist[0] : &vundefined;
-    pos = cast(int)v.toInteger();
+    pos = cast(int)v.toInteger(cc);
 
     result = TEXT_;
 
@@ -225,9 +228,9 @@ void* Dstring_prototype_charCodeAt(Dobject pthis, CallContext *cc, Dobject othis
     d_number result;
 
     v = &othis.value;
-    s = v.toString();
+    s = v.toString(cc);
     v = arglist.length ? &arglist[0] : &vundefined;
-    pos = cast(int)v.toInteger();
+    pos = cast(int)v.toInteger(cc);
 
     result = d_number.nan;
 
@@ -263,9 +266,9 @@ void* Dstring_prototype_concat(Dobject pthis, CallContext *cc, Dobject othis, Va
 
     //writefln("Dstring.prototype.concat()");
 
-    s = othis.value.toString();
+    s = othis.value.toString(cc);
     for(size_t a = 0; a < arglist.length; a++)
-        s ~= arglist[a].toString();
+        s ~= arglist[a].toString(cc);
 
     ret.putVstring(s);
     return null;
@@ -293,14 +296,14 @@ void* Dstring_prototype_indexOf(Dobject pthis, CallContext *cc, Dobject othis, V
 
     Value xx;
     xx.putVobject(othis);
-    s = xx.toString();
+    s = xx.toString(cc);
     sUCSdim = toUCSindex(s, s.length);
 
     v1 = arglist.length ? &arglist[0] : &vundefined;
     v2 = (arglist.length >= 2) ? &arglist[1] : &vundefined;
 
-    searchString = v1.toString();
-    pos = cast(int)v2.toInteger();
+    searchString = v1.toString(cc);
+    pos = cast(int)v2.toInteger(cc);
 
     if(pos < 0)
         pos = 0;
@@ -350,7 +353,7 @@ void* Dstring_prototype_lastIndexOf(Dobject pthis, CallContext *cc, Dobject othi
             a = v.Call(cc, othis, ret, null);
             if(a)                       // if exception was thrown
                 return a;
-            s = ret.toString();
+            s = ret.toString(cc);
         }
     }
     else
@@ -361,13 +364,13 @@ void* Dstring_prototype_lastIndexOf(Dobject pthis, CallContext *cc, Dobject othi
     sUCSdim = toUCSindex(s, s.length);
 
     v1 = arglist.length ? &arglist[0] : &vundefined;
-    searchString = v1.toString();
+    searchString = v1.toString(cc);
     if(arglist.length >= 2)
     {
         d_number n;
         Value *v = &arglist[1];
 
-        n = v.toNumber();
+        n = v.toNumber(cc);
         if(isNaN(n) || n > sUCSdim)
             pos = sUCSdim;
         else if(n < 0)
@@ -410,8 +413,8 @@ void* Dstring_prototype_localeCompare(Dobject pthis, CallContext *cc, Dobject ot
     Value *v;
 
     v = &othis.value;
-    s1 = v.toString();
-    s2 = arglist.length ? arglist[0].toString() : vundefined.toString();
+    s1 = v.toString(cc);
+    s2 = arglist.length ? arglist[0].toString(cc) : vundefined.toString(cc);
     n = localeCompare(cc, s1, s2);
     ret.putVnumber(n);
     return null;
@@ -426,7 +429,7 @@ void* Dstring_prototype_match(Dobject pthis, CallContext *cc, Dobject othis, Val
     Dobject o;
 
     if(arglist.length && !arglist[0].isPrimitive() &&
-       (o = arglist[0].toObject()).isDregexp())
+       (o = arglist[0].toObject(cc)).isDregexp())
     {
     }
     else
@@ -441,7 +444,7 @@ void* Dstring_prototype_match(Dobject pthis, CallContext *cc, Dobject othis, Val
     r = cast(Dregexp)o;
     if(r.global.dbool)
     {
-        Darray a = new Darray;
+        Darray a = new Darray(cc);
         d_int32 n;
         d_int32 i;
         d_int32 lasti;
@@ -451,24 +454,24 @@ void* Dstring_prototype_match(Dobject pthis, CallContext *cc, Dobject othis, Val
         for(n = 0;; n++)
         {
             r.lastIndex.putVnumber(i);
-            Dregexp.exec(r, ret, (&othis.value)[0 .. 1], EXEC_STRING);
+            Dregexp.exec(r, cc, ret, (&othis.value)[0 .. 1], EXEC_STRING);
             if(!ret.string)             // if match failed
             {
                 r.lastIndex.putVnumber(i);
                 break;
             }
             lasti = i;
-            i = cast(d_int32)r.lastIndex.toInt32();
+            i = cast(d_int32)r.lastIndex.toInt32(cc);
             if(i == lasti)              // if no source was consumed
                 i++;                    // consume a character
 
-            a.Put(n, ret, 0);           // a[n] = ret;
+            a.Put(cc, n, ret, 0);           // a[n] = ret;
         }
         ret.putVobject(a);
     }
     else
     {
-        Dregexp.exec(r, ret, (&othis.value)[0 .. 1], EXEC_ARRAY);
+        Dregexp.exec(r, cc, ret, (&othis.value)[0 .. 1], EXEC_ARRAY);
     }
     return null;
 }
@@ -498,11 +501,11 @@ void* Dstring_prototype_replace(Dobject pthis, CallContext *cc, Dobject othis, V
     Value* v;
 
     v = &othis.value;
-    string = v.toString();
+    string = v.toString(cc);
     searchValue = (arglist.length >= 1) ? &arglist[0] : &vundefined;
     replaceValue = (arglist.length >= 2) ? &arglist[1] : &vundefined;
-    r = Dregexp.isRegExp(searchValue);
-    f = Dfunction.isFunction(replaceValue);
+    r = Dregexp.isRegExp(searchValue, cc);
+    f = Dfunction.isFunction(replaceValue, cc);
     if(r)
     {
         int offset = 0;
@@ -514,7 +517,7 @@ void* Dstring_prototype_replace(Dobject pthis, CallContext *cc, Dobject othis, V
         r.lastIndex.putVnumber(0);
         for(;; )
         {
-            Dregexp.exec(r, ret, (&othis.value)[0 .. 1], EXEC_STRING);
+            Dregexp.exec(r, cc, ret, (&othis.value)[0 .. 1], EXEC_STRING);
             if(!ret.string)             // if match failed
                 break;
 
@@ -534,11 +537,11 @@ void* Dstring_prototype_replace(Dobject pthis, CallContext *cc, Dobject othis, V
                 alist[m + 1].putVnumber(re.pmatch[0].rm_so);
                 alist[m + 2].putVstring(string);
                 f.Call(cc, f, ret, alist[0 .. m + 3]);
-                replacement = ret.toString();
+                replacement = ret.toString(cc);
             }
             else
             {
-                newstring = replaceValue.toString();
+                newstring = replaceValue.toString(cc);
                 replacement = re.replace(newstring);
             }
             ptrdiff_t starti = re.pmatch[0].rm_so + offset;
@@ -553,7 +556,7 @@ void* Dstring_prototype_replace(Dobject pthis, CallContext *cc, Dobject othis, V
 
                 // If no source was consumed, consume a character
                 lasti = i;
-                i = cast(d_int32)r.lastIndex.toInt32();
+                i = cast(d_int32)r.lastIndex.toInt32(cc);
                 if(i == lasti)
                 {
                     i++;
@@ -566,7 +569,7 @@ void* Dstring_prototype_replace(Dobject pthis, CallContext *cc, Dobject othis, V
     }
     else
     {
-        searchString = searchValue.toString();
+        searchString = searchValue.toString(cc);
         ptrdiff_t match = indexOf(string, searchString);
         if(match >= 0)
         {
@@ -580,11 +583,11 @@ void* Dstring_prototype_replace(Dobject pthis, CallContext *cc, Dobject othis, V
                 alist[1].putVnumber(pmatch[0].rm_so);
                 alist[2].putVstring(string);
                 f.Call(cc, f, ret, alist);
-                replacement = ret.toString();
+                replacement = ret.toString(cc);
             }
             else
             {
-                newstring = replaceValue.toString();
+                newstring = replaceValue.toString(cc);
                 replacement = RegExp.replace3(newstring, string, pmatch);
             }
             result = string[0 .. match] ~
@@ -611,7 +614,7 @@ void* Dstring_prototype_search(Dobject pthis, CallContext *cc, Dobject othis, Va
 
     //writef("String.prototype.search()\n");
     if(arglist.length && !arglist[0].isPrimitive() &&
-       (o = arglist[0].toObject()).isDregexp())
+       (o = arglist[0].toObject(cc)).isDregexp())
     {
     }
     else
@@ -624,7 +627,7 @@ void* Dstring_prototype_search(Dobject pthis, CallContext *cc, Dobject othis, Va
     }
 
     r = cast(Dregexp)o;
-    Dregexp.exec(r, ret, (&othis.value)[0 .. 1], EXEC_INDEX);
+    Dregexp.exec(r, cc, ret, (&othis.value)[0 .. 1], EXEC_INDEX);
     return null;
 }
 
@@ -641,7 +644,7 @@ void* Dstring_prototype_slice(Dobject pthis, CallContext *cc, Dobject othis, Val
     Value *v;
 
     v = &othis.value;
-    s = v.toString();
+    s = v.toString(cc);
     sUCSdim = std.utf.toUCSindex(s, s.length);
     switch(arglist.length)
     {
@@ -651,13 +654,13 @@ void* Dstring_prototype_slice(Dobject pthis, CallContext *cc, Dobject othis, Val
         break;
 
     case 1:
-        start = arglist[0].toInt32();
+        start = arglist[0].toInt32(cc);
         end = sUCSdim;
         break;
 
     default:
-        start = arglist[0].toInt32();
-        end = arglist[1].toInt32();
+        start = arglist[0].toInt32(cc);
+        end = arglist[1].toInt32(cc);
         break;
     }
 
@@ -726,14 +729,14 @@ void* Dstring_prototype_split(Dobject pthis, CallContext *cc, Dobject othis, Val
 
     Value *v;
     v = &othis.value;
-    S = v.toString();
-    A = new Darray;
+    S = v.toString(cc);
+    A = new Darray(cc);
     if(limit.isUndefined())
         lim = ~0u;
     else
-        lim = limit.toUint32();
+        lim = limit.toUint32(cc);
     p = 0;
-    R = Dregexp.isRegExp(separator);
+    R = Dregexp.isRegExp(separator, cc);
     if(R)       // regular expression
     {
         re = R.re;
@@ -744,7 +747,7 @@ void* Dstring_prototype_split(Dobject pthis, CallContext *cc, Dobject othis, Val
     else        // string
     {
         re = null;
-        rs = separator.toString();
+        rs = separator.toString(cc);
         str = 1;
     }
     if(lim == 0)
@@ -773,7 +776,7 @@ void* Dstring_prototype_split(Dobject pthis, CallContext *cc, Dobject othis, Val
                         if(e != p)
                         {
                             T = S[p .. q];
-                            A.Put(cast(uint)A.length.number, T, 0);
+                            A.Put(cc, cast(uint)A.length.number, T, 0);
                             if(A.length.number == lim)
                                 goto Lret;
                             p = e;
@@ -791,7 +794,7 @@ void* Dstring_prototype_split(Dobject pthis, CallContext *cc, Dobject othis, Val
                         {
                             T = S[p .. q];
                             //writefln("S = '%s', T = '%s', p = %d, q = %d, e = %d\n", S, T, p, q, e);
-                            A.Put(cast(uint)A.length.number, T, 0);
+                            A.Put(cc, cast(uint)A.length.number, T, 0);
                             if(A.length.number == lim)
                                 goto Lret;
                             p = e;
@@ -805,7 +808,7 @@ void* Dstring_prototype_split(Dobject pthis, CallContext *cc, Dobject othis, Val
                                     T = S[so .. eo];
                                 else
                                     T = null;
-                                A.Put(cast(uint)A.length.number, T, 0);
+                                A.Put(cc, cast(uint)A.length.number, T, 0);
                                 if(A.length.number == lim)
                                     goto Lret;
                             }
@@ -815,7 +818,7 @@ void* Dstring_prototype_split(Dobject pthis, CallContext *cc, Dobject othis, Val
                 }
             }
             T = S[p .. S.length];
-            A.Put(cast(uint)A.length.number, T, 0);
+            A.Put(cc, cast(uint)A.length.number, T, 0);
             goto Lret;
         }
         if(str)                 // string
@@ -830,7 +833,7 @@ void* Dstring_prototype_split(Dobject pthis, CallContext *cc, Dobject othis, Val
         }
     }
 
-    A.Put(0u, S, 0);
+    A.Put(cc, 0u, S, 0);
     Lret:
     ret.putVobject(A);
     return null;
@@ -889,18 +892,18 @@ void* Dstring_prototype_substr(Dobject pthis, CallContext *cc, Dobject othis, Va
     d_number length;
     d_string s;
 
-    s = othis.value.toString();
+    s = othis.value.toString(cc);
     size_t sUCSdim = toUCSindex(s, s.length);
     start = 0;
     length = 0;
     if(arglist.length >= 1)
     {
-        start = arglist[0].toInteger();
+        start = arglist[0].toInteger(cc);
         if(start < 0)
             start = sUCSdim + start;
         if(arglist.length >= 2)
         {
-            length = arglist[1].toInteger();
+            length = arglist[1].toInteger(cc);
             if(isNaN(length) || length < 0)
                 length = 0;
         }
@@ -925,15 +928,15 @@ void* Dstring_prototype_substring(Dobject pthis, CallContext *cc, Dobject othis,
     d_string s;
 
     //writefln("String.prototype.substring()");
-    s = othis.value.toString();
+    s = othis.value.toString(cc);
     size_t sUCSdim = toUCSindex(s, s.length);
     start = 0;
     end = sUCSdim;
     if(arglist.length >= 1)
     {
-        start = arglist[0].toInteger();
+        start = arglist[0].toInteger(cc);
         if(arglist.length >= 2)
-            end = arglist[1].toInteger();
+            end = arglist[1].toInteger(cc);
         //writef("s = '%ls', start = %d, end = %d\n", s, start, end);
     }
 
@@ -951,13 +954,13 @@ enum CASE
     LocaleUpper
 };
 
-void *tocase(Dobject othis, Value *ret, CASE caseflag)
+void *tocase(Dobject othis, Value *ret, CASE caseflag, CallContext* cc)
 {
     import std.string : toLower, toUpper;
 
     d_string s;
 
-    s = othis.value.toString();
+    s = othis.value.toString(cc);
     switch(caseflag)
     {
     case CASE.Lower:
@@ -986,7 +989,7 @@ void* Dstring_prototype_toLowerCase(Dobject pthis, CallContext *cc, Dobject othi
     // String.prototype.toLowerCase()
 
     //writef("Dstring_prototype_toLowerCase()\n");
-    return tocase(othis, ret, CASE.Lower);
+    return tocase(othis, ret, CASE.Lower, cc);
 }
 
 /* ===================== Dstring_prototype_toLocaleLowerCase ============= */
@@ -996,7 +999,7 @@ void* Dstring_prototype_toLocaleLowerCase(Dobject pthis, CallContext *cc, Dobjec
     // ECMA v3 15.5.4.17
 
     //writef("Dstring_prototype_toLocaleLowerCase()\n");
-    return tocase(othis, ret, CASE.LocaleLower);
+    return tocase(othis, ret, CASE.LocaleLower, cc);
 }
 
 /* ===================== Dstring_prototype_toUpperCase ============= */
@@ -1006,7 +1009,7 @@ void* Dstring_prototype_toUpperCase(Dobject pthis, CallContext *cc, Dobject othi
     // ECMA 15.5.4.12
     // String.prototype.toUpperCase()
 
-    return tocase(othis, ret, CASE.Upper);
+    return tocase(othis, ret, CASE.Upper, cc);
 }
 
 /* ===================== Dstring_prototype_toLocaleUpperCase ============= */
@@ -1015,21 +1018,21 @@ void* Dstring_prototype_toLocaleUpperCase(Dobject pthis, CallContext *cc, Dobjec
 {
     // ECMA v3 15.5.4.18
 
-    return tocase(othis, ret, CASE.LocaleUpper);
+    return tocase(othis, ret, CASE.LocaleUpper, cc);
 }
 
 /* ===================== Dstring_prototype_anchor ============= */
 
-void *dstring_anchor(Dobject othis, Value* ret, d_string tag, d_string name, Value[] arglist)
+void *dstring_anchor(Dobject othis, CallContext* cc, Value* ret, d_string tag, d_string name, Value[] arglist)
 {
     // For example:
     //	"foo".anchor("bar")
     // produces:
     //	<tag name="bar">foo</tag>
 
-    d_string foo = othis.value.toString();
+    d_string foo = othis.value.toString(cc);
     Value* va = arglist.length ? &arglist[0] : &vundefined;
-    d_string bar = va.toString();
+    d_string bar = va.toString(cc);
 
     d_string s;
 
@@ -1059,22 +1062,22 @@ void* Dstring_prototype_anchor(Dobject pthis, CallContext *cc, Dobject othis, Va
     // produces:
     //	<A NAME="bar">foo</A>
 
-    return dstring_anchor(othis, ret, "A", "NAME", arglist);
+    return dstring_anchor(othis, cc, ret, "A", "NAME", arglist);
 }
 
 void* Dstring_prototype_fontcolor(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_anchor(othis, ret, "FONT", "COLOR", arglist);
+    return dstring_anchor(othis, cc, ret, "FONT", "COLOR", arglist);
 }
 
 void* Dstring_prototype_fontsize(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_anchor(othis, ret, "FONT", "SIZE", arglist);
+    return dstring_anchor(othis, cc, ret, "FONT", "SIZE", arglist);
 }
 
 void* Dstring_prototype_link(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_anchor(othis, ret, "A", "HREF", arglist);
+    return dstring_anchor(othis, cc, ret, "A", "HREF", arglist);
 }
 
 
@@ -1084,9 +1087,9 @@ void* Dstring_prototype_link(Dobject pthis, CallContext *cc, Dobject othis, Valu
  * Produce <tag>othis</tag>
  */
 
-void *dstring_bracket(Dobject othis, Value* ret, d_string tag)
+void *dstring_bracket(Dobject othis, CallContext* cc, Value* ret, d_string tag)
 {
-    d_string foo = othis.value.toString();
+    d_string foo = othis.value.toString(cc);
     d_string s;
 
     s = "<"     ~
@@ -1110,47 +1113,47 @@ void* Dstring_prototype_big(Dobject pthis, CallContext *cc, Dobject othis, Value
     // produces:
     //	<BIG>foo</BIG>
 
-    return dstring_bracket(othis, ret, "BIG");
+    return dstring_bracket(othis, cc, ret, "BIG");
 }
 
 void* Dstring_prototype_blink(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_bracket(othis, ret, "BLINK");
+    return dstring_bracket(othis, cc, ret, "BLINK");
 }
 
 void* Dstring_prototype_bold(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_bracket(othis, ret, "B");
+    return dstring_bracket(othis, cc, ret, "B");
 }
 
 void* Dstring_prototype_fixed(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_bracket(othis, ret, "TT");
+    return dstring_bracket(othis, cc, ret, "TT");
 }
 
 void* Dstring_prototype_italics(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_bracket(othis, ret, "I");
+    return dstring_bracket(othis, cc, ret, "I");
 }
 
 void* Dstring_prototype_small(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_bracket(othis, ret, "SMALL");
+    return dstring_bracket(othis, cc, ret, "SMALL");
 }
 
 void* Dstring_prototype_strike(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_bracket(othis, ret, "STRIKE");
+    return dstring_bracket(othis, cc, ret, "STRIKE");
 }
 
 void* Dstring_prototype_sub(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_bracket(othis, ret, "SUB");
+    return dstring_bracket(othis, cc, ret, "SUB");
 }
 
 void* Dstring_prototype_sup(Dobject pthis, CallContext *cc, Dobject othis, Value *ret, Value[] arglist)
 {
-    return dstring_bracket(othis, ret, "SUP");
+    return dstring_bracket(othis, cc, ret, "SUP");
 }
 
 
@@ -1159,11 +1162,11 @@ void* Dstring_prototype_sup(Dobject pthis, CallContext *cc, Dobject othis, Value
 
 class DstringPrototype : Dstring
 {
-    this()
+    this(CallContext* cc)
     {
-        super(Dobject_prototype);
+        super(cc, Dobject_prototype);
 
-        Put(TEXT_constructor, Dstring_constructor, DontEnum);
+        Put(cc, TEXT_constructor, Dstring_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -1201,7 +1204,7 @@ class DstringPrototype : Dstring
             { TEXT_sup, &Dstring_prototype_sup, 0 },
         ];
 
-        DnativeFunction.initialize(this, nfd, DontEnum);
+        DnativeFunction.initialize(this, cc, nfd, DontEnum);
     }
 }
 
@@ -1209,30 +1212,30 @@ class DstringPrototype : Dstring
 
 class Dstring : Dobject
 {
-    this(d_string s)
+    this(CallContext* cc, d_string s)
     {
-        super(getPrototype());
+        super(cc, getPrototype());
         classname = TEXT_String;
 
-        Put(TEXT_length, std.utf.toUCSindex(s, s.length), DontEnum | DontDelete | ReadOnly);
+        Put(cc, TEXT_length, std.utf.toUCSindex(s, s.length), DontEnum | DontDelete | ReadOnly);
         value.putVstring(s);
     }
 
-    this(Dobject prototype)
+    this(CallContext* cc, Dobject prototype)
     {
-        super(prototype);
+        super(cc, prototype);
 
         classname = TEXT_String;
-        Put(TEXT_length, 0, DontEnum | DontDelete | ReadOnly);
+        Put(cc, TEXT_length, 0, DontEnum | DontDelete | ReadOnly);
         value.putVstring(null);
     }
 
-    static void initialize()
+    static void initialize(CallContext* cc)
     {
-        Dstring_constructor = new DstringConstructor();
-        Dstring_prototype = new DstringPrototype();
+        Dstring_constructor = new DstringConstructor(cc);
+        Dstring_prototype = new DstringPrototype(cc);
 
-        Dstring_constructor.Put(TEXT_prototype, Dstring_prototype, DontEnum | DontDelete | ReadOnly);
+        Dstring_constructor.Put(cc, TEXT_prototype, Dstring_prototype, DontEnum | DontDelete | ReadOnly);
     }
 
     static Dfunction getConstructor()

--- a/engine/source/dmdscript/extending.d
+++ b/engine/source/dmdscript/extending.d
@@ -28,11 +28,11 @@ import std.typetuple;
 import std.file;
 
 
-T convert(T)(Value* v){
+T convert(T)(Value* v, CallContext* cc){
 	static if(is(T == int)){
-		return v.toInt32();
+		return v.toInt32(cc);
     }else static if(isSomeString!T ){
-        return v.toString();   
+        return v.toString(cc);   
 	}else{
 		assert(0);	
 	}
@@ -50,10 +50,10 @@ if(isCallable!fn) {
     alias ParameterTypeTuple!fn Args;
     alias ReturnType!fn R;
     alias staticMap!(Unqual,Args) Uargs;
-	static void* embedded(Dobject pthis, CallContext* cc,
-                          Dobject othis, Value* ret,	Value[] arglist){
+    static void* embedded(Dobject pthis, CallContext* cc,
+                          Dobject othis, Value* ret, Value[] arglist){
        
-        Tuple!(Uargs) tup = convertAll!(Uargs)(arglist);
+        Tuple!(Uargs) tup = convertAll!(Uargs)(arglist, cc);
         if(arglist.length < tup.length){
             auto len = arglist.length;
             arglist.length = tup.length;
@@ -69,6 +69,7 @@ if(isCallable!fn) {
         }
         return null;
     }
+
     NativeFunctionData[] nfd = [
         {
             name,
@@ -76,7 +77,8 @@ if(isCallable!fn) {
             Args.length
         }
     ];
-    DnativeFunction.initialize(pg.callcontext.global,nfd,DontEnum);
+
+    DnativeFunction.initialize(pg.callcontext.global,pg.callcontext,nfd,DontEnum);
 }
                                     
 void fitArray(T...)(ref Value[] arglist){
@@ -89,7 +91,7 @@ void fitArray(T...)(ref Value[] arglist){
     arglist = arglist[0..staticLen];
 }
                  
-void extendMethod(T,alias fn)(Dobject obj, string name)
+void extendMethod(T,alias fn)(Dobject obj, CallContext* cc, string name)
 if(is(T == class) && isCallable!fn){
     alias ParameterTypeTuple!fn Args;
     alias ReturnType!fn R;
@@ -98,7 +100,7 @@ if(is(T == class) && isCallable!fn){
                           Dobject othis, Value* ret,	Value[] arglist){
 
         static if(Uargs.length){
-            Tuple!(Uargs) tup = convertAll!(Uargs)(arglist);
+            Tuple!(Uargs) tup = convertAll!(Uargs)(arglist, cc);
         
             fitArray(arglist);
         }
@@ -124,21 +126,21 @@ if(is(T == class) && isCallable!fn){
             Args.length
         }
     ];
-    DnativeFunction.initialize(obj,nfd,DontEnum);
+    DnativeFunction.initialize(obj,cc,nfd,DontEnum);
 }                          
 class Wrap(Which,string ClassName,Base=Dobject): Base{
     Which wrapped;
     static Wrap _prototype;
     static Constructor _constructor;
     static class Constructor: Dfunction{
-        this(){
-            super(ConstructorArgs.length, Dfunction_prototype);
+        this(CallContext* cc){
+            super(cc, ConstructorArgs.length, Dfunction_prototype);
             name = ClassName;
         }
 
         override void *Construct(CallContext *cc, Value *ret, Value[] arglist){
             fitArray!(ConstructorArgs)(arglist);
-            Dobject o = new Wrap(convertAll!(UConstructorArgs)(arglist).expand);
+            Dobject o = new Wrap(cc, convertAll!(UConstructorArgs)(arglist, cc).expand);
             ret.putVobject(o);
             return null;
         }
@@ -148,42 +150,48 @@ class Wrap(Which,string ClassName,Base=Dobject): Base{
         }
     
     }
-    static void initialize(){
-         _prototype = new Wrap(Base.getPrototype());
-        _constructor = new Constructor();
-        _prototype.Put("constructor", _constructor, DontEnum);
-        _constructor.Put("prototype", _prototype, DontEnum | DontDelete | ReadOnly);
-        ctorTable[ClassName] = _constructor;
+    static void initialize(CallContext* cc){
+         _prototype = new Wrap(cc, Base.getPrototype());
+        _constructor = new Constructor(cc);
+        _prototype.Put(cc, "constructor", _constructor, DontEnum);
+        _constructor.Put(cc, "prototype", _prototype, DontEnum | DontDelete | ReadOnly);
+
+        // we need to directly store the constructor, because this will be
+        // called after the global object has already been created
+        //cc.tc.ctorTable[ClassName] = _constructor;
+        cc.global.Put(cc, ClassName, _constructor, DontEnum);
     }
     static this(){
-        threadInitTable ~= &initialize;
+        threadInitTable ~= cc => initialize(cc);
     }
-    private this(Dobject prototype){ 
-        super(prototype); 
+    private this(CallContext* cc, Dobject prototype){ 
+        super(cc, prototype); 
         classname = ClassName;
         //Put(TEXT_constructor,
     }
     alias ParameterTypeTuple!(Which.__ctor) ConstructorArgs;
     alias staticMap!(Unqual,ConstructorArgs) UConstructorArgs;
-    this(ConstructorArgs args){
-        super(_prototype);
+    this(CallContext* cc, ConstructorArgs args){
+        super(cc, _prototype);
         static if (is(Which == struct)){
             wrapped = Which(args);
         } 
     }
     static void methods(Methods...)(){
         static if(Methods.length >= 1){
-             extendMethod!(Wrap,Methods[0])(_prototype,(&Methods[0]).stringof[2..$]);
+            threadInitTable ~= (cc) {
+                extendMethod!(Wrap,Methods[0])(_prototype,cc,(&Methods[0]).stringof[2..$]);
+            };
         
-             methods!(Methods[1..$])();
+            methods!(Methods[1..$])();
         }
     }
 }       
                         
-auto convertAll(Args...)(Value[] dest){
+auto convertAll(Args...)(Value[] dest, CallContext* cc){
     static if(Args.length > 1){
-        return tuple(convert!(Args[0])(&dest[0]),convertAll!(Args[1..$])(dest[1..$]).expand);  
+        return tuple(convert!(Args[0])(&dest[0], cc),convertAll!(Args[1..$])(dest[1..$], cc).expand);  
     }else 
-        return tuple(convert!(Args[0])(&dest[0]));
+        return tuple(convert!(Args[0])(&dest[0], cc));
 }
 

--- a/engine/source/dmdscript/functiondefinition.d
+++ b/engine/source/dmdscript/functiondefinition.d
@@ -238,7 +238,7 @@ class FunctionDefinition : TopStatement
         nlocals = irs.nlocals;
     }
 
-    void instantiate(Dobject[] scopex, Dobject actobj, uint attributes)
+    void instantiate(CallContext* cc, Dobject[] scopex, Dobject actobj, uint attributes)
     {
         //writefln("FunctionDefinition.instantiate() %s nestDepth = %d", name ? name.toString() : "", nestDepth);
 
@@ -247,20 +247,20 @@ class FunctionDefinition : TopStatement
         {
             // If name is already declared, don't override it
             //writefln("\tVar Put(%s)", name.toString());
-            actobj.Put(name.toString(), &vundefined, Instantiate | DontOverride | attributes);
+            actobj.Put(cc, name.toString(), &vundefined, Instantiate | DontOverride | attributes);
         }
 
         // Instantiate the Function's per 10.1.3
         foreach(FunctionDefinition fd; functiondefinitions)
         {
             // Set [[Scope]] property per 13.2 step 7
-            Dfunction fobject = new DdeclaredFunction(fd);
+            Dfunction fobject = new DdeclaredFunction(cc, fd);
             fobject.scopex = scopex;
 
             if(fd.name !is null && !fd.isliteral)        // skip anonymous functions
             {
                 //writefln("\tFunction Put(%s)", fd.name.toString());
-                actobj.Put(fd.name.toString(), fobject, Instantiate | attributes);
+                actobj.Put(cc, fd.name.toString(), fobject, Instantiate | attributes);
             }
         }
         //writefln("-FunctionDefinition.instantiate()");

--- a/engine/source/dmdscript/identifier.d
+++ b/engine/source/dmdscript/identifier.d
@@ -43,7 +43,7 @@ struct Identifier
     {
         Identifier* id = new Identifier;
         id.value.putVstring(s);
-        id.value.toHash();
+        id.value.hashString();
         return id;
     }
 

--- a/engine/source/dmdscript/iterator.d
+++ b/engine/source/dmdscript/iterator.d
@@ -50,6 +50,7 @@ struct Iterator
     size_t  keyindex;
     Dobject o;
     Dobject ostart;
+    CallContext* callcontext;
 
     debug
     {
@@ -62,13 +63,14 @@ struct Iterator
         debug assert(foo == ITERATOR_VALUE);
     }
 
-    void ctor(Dobject o)
+    void ctor(CallContext* cc, Dobject o)
     {
         debug foo = ITERATOR_VALUE;
         //writef("Iterator: o = %p, p = %p\n", o, p);
         ostart = o;
         this.o = o;
-        keys = o.proptable.table.keys.sort().release;
+        this.callcontext = cc;
+        keys = o.proptable.table.keys.sort!((a, b) => a.compare(cc, b) < 0).release;
         keyindex = 0;
     }
 
@@ -86,7 +88,7 @@ struct Iterator
                 o = getPrototype(o);
                 if(!o)
                     return null;
-                keys = o.proptable.table.keys.sort().release;
+                keys = o.proptable.table.keys.sort!((a, b) => a.compare(this.callcontext, b) < 0).release;
                 keyindex = 0;
             }
             Value* key = &keys[keyindex];

--- a/engine/source/dmdscript/lexer.d
+++ b/engine/source/dmdscript/lexer.d
@@ -629,7 +629,7 @@ class Lexer
                           i = id in stringtable;
                       }
                       i.value.putVstring(id);
-                      i.value.toHash();
+                      i.value.hashString();
                       t.ident = i;
                   }
                   else

--- a/engine/source/dmdscript/opcodes.d
+++ b/engine/source/dmdscript/opcodes.d
@@ -67,9 +67,9 @@ class Catch : Dobject
     uint offset;        // offset of CatchBlock
     d_string name;      // catch identifier
 
-    this(uint offset, d_string name)
+    this(CallContext* cc, uint offset, d_string name)
     {
-        super(null);
+        super(cc, null);
         this.offset = offset;
         this.name = name;
     }
@@ -97,9 +97,9 @@ class Finally : Dobject
 
     IR *finallyblock;    // code for FinallyBlock
 
-    this(IR * finallyblock)
+    this(CallContext* cc, IR * finallyblock)
     {
-        super(null);
+        super(cc, null);
         this.finallyblock = finallyblock;
     }
 
@@ -246,7 +246,7 @@ void PutValue(CallContext *cc, d_string s, Value* a)
     if(d == cc.globalroot)
     {
         o = scope_tos(cc.scopex);
-        o.Put(s, a, 0);
+        o.Put(cc, s, a, 0);
         return;
     }
 
@@ -261,13 +261,13 @@ void PutValue(CallContext *cc, d_string s, Value* a)
         if(v)
         {
             // Overwrite existing property with new one
-            v.checkReference();
-            o.Put(s, a, 0);
+            v.checkReference(cc);
+            o.Put(cc, s, a, 0);
             break;
         }
         if(d == cc.globalroot)
         {
-            o.Put(s, a, 0);
+            o.Put(cc, s, a, 0);
             return;
         }
     }
@@ -299,14 +299,14 @@ void PutValue(CallContext *cc, Identifier* id, Value* a)
             v = o.Get(id);
             if(v)
             {
-                v.checkReference();
+                v.checkReference(cc);
                 break;// Overwrite existing property with new one
             }
             if(d == cc.globalroot)
                 break;
         }
     }
-    o.Put(id, a, 0);
+    o.Put(cc, id, a, 0);
 }
 
 
@@ -314,20 +314,20 @@ void PutValue(CallContext *cc, Identifier* id, Value* a)
  * Helper function for Values that cannot be converted to Objects.
  */
 
-Value* cannotConvert(Value* b, int linnum)
+Value* cannotConvert(Value* b, CallContext* cc, int linnum)
 {
     ErrInfo errinfo;
 
     errinfo.linnum = linnum;
     if(b.isUndefinedOrNull())
     {
-        b = Dobject.RuntimeError(&errinfo, errmsgtbl[ERR_CANNOT_CONVERT_TO_OBJECT4],
+        b = Dobject.RuntimeError(&errinfo, cc, errmsgtbl[ERR_CANNOT_CONVERT_TO_OBJECT4],
                                  b.getType());
     }
     else
     {
-        b = Dobject.RuntimeError(&errinfo, errmsgtbl[ERR_CANNOT_CONVERT_TO_OBJECT2],
-                                 b.getType(), b.toString());
+        b = Dobject.RuntimeError(&errinfo, cc, errmsgtbl[ERR_CANNOT_CONVERT_TO_OBJECT2],
+                                 b.getType(), b.toString(cc));
     }
     return b;
 }
@@ -446,14 +446,14 @@ struct IR
                     {
                         ca = cast(Catch)o;
                         //writef("catch('%s')\n", ca.name);
-                        o = new Dobject(Dobject.getPrototype());
+                        o = new Dobject(cc, Dobject.getPrototype());
                         version(JSCRIPT_CATCH_BUG)
                         {
                             PutValue(cc, ca.name, a);
                         }
                         else
                         {
-                            o.Put(ca.name, a, DontDelete);
+                            o.Put(cc, ca.name, a, DontDelete);
                         }
                         scopex ~= o;
                         cc.scopex = scopex;
@@ -641,10 +641,10 @@ struct IR
                 case IRget:                 // a = b.c
                     a = GETa(code);
                     b = GETb(code);
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     if(!o)
                     {
-                        a = cannotConvert(b, GETlinnum(code));
+                        a = cannotConvert(b, cc, GETlinnum(code));
                         goto Lthrow;
                     }
                     c = GETc(code);
@@ -657,7 +657,7 @@ struct IR
                     }
                     else
                     {
-                        s = c.toString();
+                        s = c.toString(cc);
                         v = o.Get(s);
                     }
                     if(!v)
@@ -676,14 +676,14 @@ struct IR
                     {
                         //writef("IRput %d\n", i32);
                         if(b.vtype == V_OBJECT)
-                            a = b.object.Put(cast(d_uint32)i32, c, a, 0);
+                            a = b.object.Put(cc, cast(d_uint32)i32, c, a, 0);
                         else
-                            a = b.Put(cast(d_uint32)i32, c, a);
+                            a = b.Put(cc, cast(d_uint32)i32, c, a);
                     }
                     else
                     {
-                        s = c.toString();
-                        a = b.Put(s, a);
+                        s = c.toString(cc);
+                        a = b.Put(cc, s, a);
                     }
                     if(a)
                         goto Lthrow;
@@ -694,14 +694,15 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     s = (code + 3).id.value.string;
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     if(!o)
                     {
                         //writef("%s %s.%s cannot convert to Object", b.getType(), b.toString(), s);
                         ErrInfo errinfo;
                         a = Dobject.RuntimeError(&errinfo,
+                                                 cc,
                                                  errmsgtbl[ERR_CANNOT_CONVERT_TO_OBJECT3],
-                                                 b.getType(), b.toString(),
+                                                 b.getType(), b.toString(cc),
                                                  s);
                         goto Lthrow;
                     }
@@ -718,7 +719,7 @@ struct IR
 	                id = (code+1).id;
 	                s = id.value.string;
 	                if(!scope_get(scopex, id))
-		                throw new ErrorValue(Dobject.ReferenceError(errmsgtbl[ERR_UNDEFINED_VAR],s)); 
+		                throw new ErrorValue(Dobject.ReferenceError(cc, errmsgtbl[ERR_UNDEFINED_VAR],s)); 
 	                code += 2;
 	                break;
                 case IRgetscope:            // a = s
@@ -766,14 +767,14 @@ struct IR
 
                 case IRaddass:              // a = (b.c += a)
                     c = GETc(code);
-                    s = c.toString();
+                    s = c.toString(cc);
                     goto Laddass;
 
                 case IRaddasss:             // a = (b.s += a)
                     s = (code + 3).id.value.string;
                     Laddass:
                     b = GETb(code);
-                    v = b.Get(s);
+                    v = b.Get(cc, s);
                     goto Laddass2;
 
                 case IRaddassscope:         // a = (s += a)
@@ -796,7 +797,7 @@ struct IR
                     a = GETa(code);
                     if(!v)
                     {
-						throw new ErrorValue(Dobject.ReferenceError(errmsgtbl[ERR_UNDEFINED_VAR],s));
+						throw new ErrorValue(Dobject.ReferenceError(cc, errmsgtbl[ERR_UNDEFINED_VAR],s));
                         //a.putVundefined();
                         /+
                                             if (b)
@@ -817,23 +818,23 @@ struct IR
                     }
                     else
                     {
-                        v.toPrimitive(v, null);
-                        a.toPrimitive(a, null);
+                        v.toPrimitive(cc, v, null);
+                        a.toPrimitive(cc, a, null);
                         if(v.isString())
                         {
-                            s2 = v.toString() ~a.toString();
+                            s2 = v.toString(cc) ~a.toString(cc);
                             a.putVstring(s2);
                             Value.copy(v, a);
                         }
                         else if(a.isString())
                         {
-                            s2 = v.toString() ~a.toString();
+                            s2 = v.toString(cc) ~a.toString(cc);
                             a.putVstring(s2);
                             Value.copy(v, a);
                         }
                         else
                         {
-                            a.putVnumber(a.toNumber() + v.toNumber());
+                            a.putVnumber(a.toNumber(cc) + v.toNumber(cc));
                             *v = *a;//full copy
                         }
                     }
@@ -843,13 +844,13 @@ struct IR
                 case IRputs:            // b.s = a
                     a = GETa(code);
                     b = GETb(code);
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     if(!o)
                     {
-                        a = cannotConvert(b, GETlinnum(code));
+                        a = cannotConvert(b, cc, GETlinnum(code));
                         goto Lthrow;
                     }
-                    a = o.Put((code + 3).id.value.string, a, 0);
+                    a = o.Put(cc, (code + 3).id.value.string, a, 0);
                     if(a)
                         goto Lthrow;
                     code += 4;
@@ -857,7 +858,7 @@ struct IR
 
                 case IRputscope:            // s = a
                     a = GETa(code);
-                    a.checkReference();
+                    a.checkReference(cc);
                     PutValue(cc, (code + 2).id, a);
                     code += 3;
                     break;
@@ -865,16 +866,17 @@ struct IR
                 case IRputdefault:              // b = a
                     a = GETa(code);
                     b = GETb(code);
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     if(!o)
                     {
                         ErrInfo errinfo;
                         a = Dobject.RuntimeError(&errinfo,
+                                                 cc,
                                                  errmsgtbl[ERR_CANNOT_ASSIGN], a.getType(),
                                                  b.getType());
                         goto Lthrow;
                     }
-                    a = o.PutDefault(a);
+                    a = o.PutDefault(cc, a);
                     if(a)
                         goto Lthrow;
                     code += 3;
@@ -885,9 +887,9 @@ struct IR
                     o = scope_tos(scopex);
                     assert(o);
                     if(o.HasProperty((code + 2).id.value.string))
-                        a = o.Put((code+2).id.value.string,GETa(code),DontDelete);
+                        a = o.Put(cc, (code+2).id.value.string,GETa(code),DontDelete);
                     else
-                        a = cc.variable.Put((code + 2).id.value.string, GETa(code), DontDelete);
+                        a = cc.variable.Put(cc, (code + 2).id.value.string, GETa(code), DontDelete);
                     if (a) goto Lthrow;
                     code += 3;
                     break;
@@ -905,7 +907,7 @@ struct IR
                 case IRobject:              // a = object
                 { FunctionDefinition fd;
                   fd = cast(FunctionDefinition)(code + 2).ptr;
-                  Dfunction fobject = new DdeclaredFunction(fd);
+                  Dfunction fobject = new DdeclaredFunction(cc, fd);
                   fobject.scopex = scopex;
                   GETa(code).putVobject(fobject);
                   code += 3;
@@ -948,28 +950,28 @@ struct IR
 
                 case IRneg:                 // a = -a
                     a = GETa(code);
-                    n = a.toNumber();
+                    n = a.toNumber(cc);
                     a.putVnumber(-n);
                     code += 2;
                     break;
 
                 case IRpos:                 // a = a
                     a = GETa(code);
-                    n = a.toNumber();
+                    n = a.toNumber(cc);
                     a.putVnumber(n);
                     code += 2;
                     break;
 
                 case IRcom:                 // a = ~a
                     a = GETa(code);
-                    i32 = a.toInt32();
+                    i32 = a.toInt32(cc);
                     a.putVnumber(~i32);
                     code += 2;
                     break;
 
                 case IRnot:                 // a = !a
                     a = GETa(code);
-                    a.putVboolean(!a.toBoolean());
+                    a.putVboolean(!a.toBoolean(cc));
                     code += 2;
                     break;
 
@@ -990,19 +992,20 @@ struct IR
                     // ECMA v3 11.8.6
 
                     b = GETb(code);
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     c = GETc(code);
                     if(c.isPrimitive())
                     {
                         ErrInfo errinfo;
                         a = Dobject.RuntimeError(&errinfo,
+                                                 cc,
                                                  errmsgtbl[ERR_RHS_MUST_BE_OBJECT],
                                                  "instanceof", c.getType());
                         goto Lthrow;
                     }
-                    co = c.toObject();
+                    co = c.toObject(cc);
                     a = GETa(code);
-                    v = cast(Value*)co.HasInstance(a, b);
+                    v = cast(Value*)co.HasInstance(cc, a, b);
                     if(v)
                     {
                         a = v;
@@ -1027,17 +1030,17 @@ struct IR
                         char[Value.sizeof] vtmpc;
                         Value* vc = cast(Value*)vtmpc;
 
-                        b.toPrimitive(vb, null);
-                        c.toPrimitive(vc, null);
+                        b.toPrimitive(cc, vb, null);
+                        c.toPrimitive(cc, vc, null);
 
                         if(vb.isString() || vc.isString())
                         {
-                            s = vb.toString() ~vc.toString();
+                            s = vb.toString(cc) ~vc.toString(cc);
                             a.putVstring(s);
                         }
                         else
                         {
-                            a.putVnumber(vb.toNumber() + vc.toNumber());
+                            a.putVnumber(vb.toNumber(cc) + vc.toNumber(cc));
                         }
                     }
 
@@ -1048,7 +1051,7 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     c = GETc(code);
-                    a.putVnumber(b.toNumber() - c.toNumber());
+                    a.putVnumber(b.toNumber(cc) - c.toNumber(cc));
                     code += 4;
                     break;
 
@@ -1056,7 +1059,7 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     c = GETc(code);
-                    a.putVnumber(b.toNumber() * c.toNumber());
+                    a.putVnumber(b.toNumber(cc) * c.toNumber(cc));
                     code += 4;
                     break;
 
@@ -1066,7 +1069,7 @@ struct IR
                     c = GETc(code);
 
                     //writef("%g / %g = %g\n", b.toNumber() , c.toNumber(), b.toNumber() / c.toNumber());
-                    a.putVnumber(b.toNumber() / c.toNumber());
+                    a.putVnumber(b.toNumber(cc) / c.toNumber(cc));
                     code += 4;
                     break;
 
@@ -1074,7 +1077,7 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     c = GETc(code);
-                    a.putVnumber(b.toNumber() % c.toNumber());
+                    a.putVnumber(b.toNumber(cc) % c.toNumber(cc));
                     code += 4;
                     break;
 
@@ -1082,8 +1085,8 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     c = GETc(code);
-                    i32 = b.toInt32();
-                    u32 = c.toUint32() & 0x1F;
+                    i32 = b.toInt32(cc);
+                    u32 = c.toUint32(cc) & 0x1F;
                     i32 <<= u32;
                     a.putVnumber(i32);
                     code += 4;
@@ -1093,8 +1096,8 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     c = GETc(code);
-                    i32 = b.toInt32();
-                    u32 = c.toUint32() & 0x1F;
+                    i32 = b.toInt32(cc);
+                    u32 = c.toUint32(cc) & 0x1F;
                     i32 >>= cast(d_int32)u32;
                     a.putVnumber(i32);
                     code += 4;
@@ -1104,8 +1107,8 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     c = GETc(code);
-                    i32 = b.toUint32();
-                    u32 = c.toUint32() & 0x1F;
+                    i32 = b.toUint32(cc);
+                    u32 = c.toUint32(cc) & 0x1F;
                     u32 = (cast(d_uint32)i32) >> u32;
                     a.putVnumber(u32);
                     code += 4;
@@ -1115,7 +1118,7 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     c = GETc(code);
-                    a.putVnumber(b.toInt32() & c.toInt32());
+                    a.putVnumber(b.toInt32(cc) & c.toInt32(cc));
                     code += 4;
                     break;
 
@@ -1123,7 +1126,7 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     c = GETc(code);
-                    a.putVnumber(b.toInt32() | c.toInt32());
+                    a.putVnumber(b.toInt32(cc) | c.toInt32(cc));
                     code += 4;
                     break;
 
@@ -1131,18 +1134,18 @@ struct IR
                     a = GETa(code);
                     b = GETb(code);
                     c = GETc(code);
-                    a.putVnumber(b.toInt32() ^ c.toInt32());
+                    a.putVnumber(b.toInt32(cc) ^ c.toInt32(cc));
                     code += 4;
                     break;
 				case IRin:          // a = b in c
 					a = GETa(code);
 					b = GETb(code);
 					c = GETc(code);
-					s = b.toString();
-					o = c.toObject();
+					s = b.toString(cc);
+					o = c.toObject(cc);
 					if(!o){
 						ErrInfo errinfo;
-						throw new ErrorValue(Dobject.RuntimeError(&errinfo,errmsgtbl[ERR_RHS_MUST_BE_OBJECT],"in",c.toString()));
+						throw new ErrorValue(Dobject.RuntimeError(&errinfo,cc,errmsgtbl[ERR_RHS_MUST_BE_OBJECT],"in",c.toString(cc)));
 					}
 					a.putVboolean(o.HasProperty(s));
 					code += 4;
@@ -1152,7 +1155,7 @@ struct IR
 
                 case IRpreinc:     // a = ++b.c
                     c = GETc(code);
-                    s = c.toString();
+                    s = c.toString(cc);
                     goto Lpreinc;
                 case IRpreincs:    // a = ++b.s
                     s = (code + 3).id.value.string;
@@ -1161,12 +1164,12 @@ struct IR
                     Lpre:
                     a = GETa(code);
                     b = GETb(code);
-                    v = b.Get(s);
+                    v = b.Get(cc, s);
                     if(!v)
                         v = &vundefined;
-                    n = v.toNumber();
+                    n = v.toNumber(cc);
                     a.putVnumber(n + inc);
-                    b.Put(s, a);
+                    b.Put(cc, s, a);
                     code += 4;
                     break;
 
@@ -1182,7 +1185,7 @@ struct IR
                         if(s is scopecache[si].s)
                         {
                             v = scopecache[si].v;
-                            n = v.toNumber() + inc;
+                            n = v.toNumber(cc) + inc;
                             v.putVnumber(n);
                             a.putVnumber(n);
                         }
@@ -1191,14 +1194,14 @@ struct IR
                             v = scope_get(scopex, id, &o);
                             if(v)
                             {
-                                n = v.toNumber() + inc;
+                                n = v.toNumber(cc) + inc;
                                 v.putVnumber(n);
                                 a.putVnumber(n);
                             }
                             else
                             {
                                 //FIXED: as per ECMA v5 should throw ReferenceError
-                                a = Dobject.ReferenceError(errmsgtbl[ERR_UNDEFINED_VAR], s);
+                                a = Dobject.ReferenceError(cc,errmsgtbl[ERR_UNDEFINED_VAR], s);
                                 //a.putVundefined();
                                 goto Lthrow;
                             }
@@ -1209,19 +1212,19 @@ struct IR
                         v = scope_get(scopex, id, &o);
                         if(v)
                         {
-                            n = v.toNumber();
+                            n = v.toNumber(cc);
                             v.putVnumber(n + inc);
                             Value.copy(a, v);
                         }
                         else
-                             throw new ErrorValue(Dobject.ReferenceError(errmsgtbl[ERR_UNDEFINED_VAR], s));
+                             throw new ErrorValue(Dobject.ReferenceError(cc,errmsgtbl[ERR_UNDEFINED_VAR], s));
                     }
                     code += 4;
                     break;
 
                 case IRpredec:     // a = --b.c
                     c = GETc(code);
-                    s = c.toString();
+                    s = c.toString(cc);
                     goto Lpredec;
                 case IRpredecs:    // a = --b.s
                     s = (code + 3).id.value.string;
@@ -1237,19 +1240,19 @@ struct IR
 
                 case IRpostinc:     // a = b.c++
                     c = GETc(code);
-                    s = c.toString();
+                    s = c.toString(cc);
                     goto Lpostinc;
                 case IRpostincs:    // a = b.s++
                     s = (code + 3).id.value.string;
                     Lpostinc:
                     a = GETa(code);
                     b = GETb(code);
-                    v = b.Get(s);
+                    v = b.Get(cc, s);
                     if(!v)
                         v = &vundefined;
-                    n = v.toNumber();
+                    n = v.toNumber(cc);
                     a.putVnumber(n + 1);
-                    b.Put(s, a);
+                    b.Put(cc, s, a);
                     a.putVnumber(n);
                     code += 4;
                     break;
@@ -1260,7 +1263,7 @@ struct IR
                     if(v && v != &vundefined)
                     {
                         a = GETa(code);
-                        n = v.toNumber();
+                        n = v.toNumber(cc);
                         v.putVnumber(n + 1);
                         a.putVnumber(n);
                     }
@@ -1268,7 +1271,7 @@ struct IR
                     {
                         //GETa(code).putVundefined();
                         //FIXED: as per ECMA v5 should throw ReferenceError
-                        throw new ErrorValue(Dobject.ReferenceError(id.value.string));
+                        throw new ErrorValue(Dobject.ReferenceError(cc,id.value.string));
                         //v = signalingUndefined(id.value.string);
                     }
                     code += 3;
@@ -1276,19 +1279,19 @@ struct IR
 
                 case IRpostdec:     // a = b.c--
                     c = GETc(code);
-                    s = c.toString();
+                    s = c.toString(cc);
                     goto Lpostdec;
                 case IRpostdecs:    // a = b.s--
                     s = (code + 3).id.value.string;
                     Lpostdec:
                     a = GETa(code);
                     b = GETb(code);
-                    v = b.Get(s);
+                    v = b.Get(cc, s);
                     if(!v)
                         v = &vundefined;
-                    n = v.toNumber();
+                    n = v.toNumber(cc);
                     a.putVnumber(n - 1);
-                    b.Put(s, a);
+                    b.Put(cc, s, a);
                     a.putVnumber(n);
                     code += 4;
                     break;
@@ -1298,7 +1301,7 @@ struct IR
                     v = scope_get(scopex, id, &o);
                     if(v && v != &vundefined)
                     {
-                        n = v.toNumber();
+                        n = v.toNumber(cc);
                         a = GETa(code);
                         v.putVnumber(n - 1);
                         a.putVnumber(n);
@@ -1307,7 +1310,7 @@ struct IR
                     {
                         //GETa(code).putVundefined();
                         //FIXED: as per ECMA v5 should throw ReferenceError
-                        throw new ErrorValue(Dobject.ReferenceError(id.value.string));
+                        throw new ErrorValue(Dobject.ReferenceError(cc,id.value.string));
                         //v = signalingUndefined(id.value.string);
                     }
                     code += 3;
@@ -1320,14 +1323,14 @@ struct IR
                         bo = true;
                     else
                     {
-                        o = b.toObject();
+                        o = b.toObject(cc);
                         if(!o)
                         {
-                            a = cannotConvert(b, GETlinnum(code));
+                            a = cannotConvert(b, cc, GETlinnum(code));
                             goto Lthrow;
                         }
                         s = (code.opcode == IRdel)
-                            ? GETc(code).toString()
+                            ? GETc(code).toString(cc)
                             : (code + 3).id.value.string;
                         if(o.implementsDelete())
                             bo = o.Delete(s);
@@ -1365,17 +1368,17 @@ struct IR
                         res = (b.number < c.number);
                     else
                     {
-                        b.toPrimitive(b, TypeNumber);
-                        c.toPrimitive(c, TypeNumber);
+                        b.toPrimitive(cc, b, TypeNumber);
+                        c.toPrimitive(cc, c, TypeNumber);
                         if(b.isString() && c.isString())
                         {
-                            d_string x = b.toString();
-                            d_string y = c.toString();
+                            d_string x = b.toString(cc);
+                            d_string y = c.toString(cc);
 
                             res = std.string.cmp(x, y) < 0;
                         }
                         else
-                            res = b.toNumber() < c.toNumber();
+                            res = b.toNumber(cc) < c.toNumber(cc);
                     }
                     a.putVboolean(res);
                     code += 4;
@@ -1389,17 +1392,17 @@ struct IR
                         res = (b.number <= c.number);
                     else
                     {
-                        b.toPrimitive(b, TypeNumber);
-                        c.toPrimitive(c, TypeNumber);
+                        b.toPrimitive(cc, b, TypeNumber);
+                        c.toPrimitive(cc, c, TypeNumber);
                         if(b.isString() && c.isString())
                         {
-                            d_string x = b.toString();
-                            d_string y = c.toString();
+                            d_string x = b.toString(cc);
+                            d_string y = c.toString(cc);
 
                             res = std.string.cmp(x, y) <= 0;
                         }
                         else
-                            res = b.toNumber() <= c.toNumber();
+                            res = b.toNumber(cc) <= c.toNumber(cc);
                     }
                     a.putVboolean(res);
                     code += 4;
@@ -1413,17 +1416,17 @@ struct IR
                         res = (b.number > c.number);
                     else
                     {
-                        b.toPrimitive(b, TypeNumber);
-                        c.toPrimitive(c, TypeNumber);
+                        b.toPrimitive(cc, b, TypeNumber);
+                        c.toPrimitive(cc, c, TypeNumber);
                         if(b.isString() && c.isString())
                         {
-                            d_string x = b.toString();
-                            d_string y = c.toString();
+                            d_string x = b.toString(cc);
+                            d_string y = c.toString(cc);
 
                             res = std.string.cmp(x, y) > 0;
                         }
                         else
-                            res = b.toNumber() > c.toNumber();
+                            res = b.toNumber(cc) > c.toNumber(cc);
                     }
                     a.putVboolean(res);
                     code += 4;
@@ -1438,17 +1441,17 @@ struct IR
                         res = (b.number >= c.number);
                     else
                     {
-                        b.toPrimitive(b, TypeNumber);
-                        c.toPrimitive(c, TypeNumber);
+                        b.toPrimitive(cc, b, TypeNumber);
+                        c.toPrimitive(cc, c, TypeNumber);
                         if(b.isString() && c.isString())
                         {
-                            d_string x = b.toString();
-                            d_string y = c.toString();
+                            d_string x = b.toString(cc);
+                            d_string y = c.toString(cc);
 
                             res = std.string.cmp(x, y) >= 0;
                         }
                         else
-                            res = b.toNumber() >= c.toNumber();
+                            res = b.toNumber(cc) >= c.toNumber(cc);
                     }
                     a.putVboolean(res);
                     code += 4;
@@ -1500,27 +1503,27 @@ struct IR
                         res = true;
                     else if(tx == TypeNumber && ty == TypeString)
                     {
-                        c.putVnumber(c.toNumber());
+                        c.putVnumber(c.toNumber(cc));
                         goto Lagain;
                     }
                     else if(tx == TypeString && ty == TypeNumber)
                     {
-                        b.putVnumber(b.toNumber());
+                        b.putVnumber(b.toNumber(cc));
                         goto Lagain;
                     }
                     else if(tx == TypeBoolean)
                     {
-                        b.putVnumber(b.toNumber());
+                        b.putVnumber(b.toNumber(cc));
                         goto Lagain;
                     }
                     else if(ty == TypeBoolean)
                     {
-                        c.putVnumber(c.toNumber());
+                        c.putVnumber(c.toNumber(cc));
                         goto Lagain;
                     }
                     else if(ty == TypeObject)
                     {
-                        v = cast(Value*)c.toPrimitive(c, null);
+                        v = cast(Value*)c.toPrimitive(cc, c, null);
                         if(v)
                         {
                             a = v;
@@ -1530,7 +1533,7 @@ struct IR
                     }
                     else if(tx == TypeObject)
                     {
-                        v = cast(Value*)b.toPrimitive(b, null);
+                        v = cast(Value*)b.toPrimitive(cc, b, null);
                         if(v)
                         {
                             a = v;
@@ -1601,7 +1604,7 @@ struct IR
 
                 case IRjt:          // if (b) goto t
                     b = GETb(code);
-                    if(b.toBoolean())
+                    if(b.toBoolean(cc))
                         code += (code + 1).offset;
                     else
                         code += 3;
@@ -1609,7 +1612,7 @@ struct IR
 
                 case IRjf:          // if (!b) goto t
                     b = GETb(code);
-                    if(!b.toBoolean())
+                    if(!b.toBoolean(cc))
                         code += (code + 1).offset;
                     else
                         code += 3;
@@ -1648,17 +1651,17 @@ struct IR
                     }
                     else
                     {
-                        b.toPrimitive(b, TypeNumber);
-                        c.toPrimitive(c, TypeNumber);
+                        b.toPrimitive(cc, b, TypeNumber);
+                        c.toPrimitive(cc, c, TypeNumber);
                         if(b.isString() && c.isString())
                         {
-                            d_string x = b.toString();
-                            d_string y = c.toString();
+                            d_string x = b.toString(cc);
+                            d_string y = c.toString(cc);
 
                             res = std.string.cmp(x, y) < 0;
                         }
                         else
-                            res = b.toNumber() < c.toNumber();
+                            res = b.toNumber(cc) < c.toNumber(cc);
                     }
                     if(!res)
                         code += (code + 1).offset;
@@ -1679,17 +1682,17 @@ struct IR
                     }
                     else
                     {
-                        b.toPrimitive(b, TypeNumber);
-                        c.toPrimitive(c, TypeNumber);
+                        b.toPrimitive(cc, b, TypeNumber);
+                        c.toPrimitive(cc, c, TypeNumber);
                         if(b.isString() && c.isString())
                         {
-                            d_string x = b.toString();
-                            d_string y = c.toString();
+                            d_string x = b.toString(cc);
+                            d_string y = c.toString(cc);
 
                             res = std.string.cmp(x, y) <= 0;
                         }
                         else
-                            res = b.toNumber() <= c.toNumber();
+                            res = b.toNumber(cc) <= c.toNumber(cc);
                     }
                     if(!res)
                         code += (code + 1).offset;
@@ -1699,7 +1702,7 @@ struct IR
 
                 case IRjltc:        // if (b < constant) goto c
                     b = GETb(code);
-                    res = (b.toNumber() < *cast(d_number *)(code + 3));
+                    res = (b.toNumber(cc) < *cast(d_number *)(code + 3));
                     if(!res)
                         code += (code + 1).offset;
                     else
@@ -1708,7 +1711,7 @@ struct IR
 
                 case IRjlec:        // if (b <= constant) goto c
                     b = GETb(code);
-                    res = (b.toNumber() <= *cast(d_number *)(code + 3));
+                    res = (b.toNumber(cc) <= *cast(d_number *)(code + 3));
                     if(!res)
                         code += (code + 1).offset;
                     else
@@ -1718,13 +1721,13 @@ struct IR
                 case IRiter:                // a = iter(b)
                     a = GETa(code);
                     b = GETb(code);
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     if(!o)
                     {
-                        a = cannotConvert(b, GETlinnum(code));
+                        a = cannotConvert(b, cc, GETlinnum(code));
                         goto Lthrow;
                     }
-                    a = o.putIterator(a);
+                    a = o.putIterator(cc, a);
                     if(a)
                         goto Lthrow;
                     code += 3;
@@ -1732,7 +1735,7 @@ struct IR
 
                 case IRnext:        // a, b.c, iter
                                     // if (!(b.c = iter)) goto a; iter = iter.next
-                    s = GETc(code).toString();
+                    s = GETc(code).toString(cc);
                     goto case_next;
 
                 case IRnexts:       // a, b.s, iter
@@ -1745,7 +1748,7 @@ struct IR
                     else
                     {
                         b = GETb(code);
-                        b.Put(s, v);
+                        b.Put(cc, s, v);
                         code += 5;
                     }
                     break;
@@ -1759,13 +1762,13 @@ struct IR
                     else
                     {
                         o = scope_tos(scopex);
-                        o.Put(s, v, 0);
+                        o.Put(cc, s, v, 0);
                         code += 4;
                     }
                     break;
 
                 case IRcall:        // a = b.c(argc, argv)
-                    s = GETc(code).toString();
+                    s = GETc(code).toString(cc);
                     goto case_call;
 
                 case IRcalls:       // a = b.s(argc, argv)
@@ -1775,7 +1778,7 @@ struct IR
                     case_call:               
                     a = GETa(code);
                     b = GETb(code);
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     if(!o)
                     {
                         goto Lcallerror;
@@ -1803,8 +1806,9 @@ struct IR
                         //writef("%s %s.%s is undefined and has no Call method\n", b.getType(), b.toString(), s);
                         ErrInfo errinfo;
                         a = Dobject.RuntimeError(&errinfo,
+                                                 cc,
                                                  errmsgtbl[ERR_UNDEFINED_NO_CALL3],
-                                                 b.getType(), b.toString(),
+                                                 b.getType(), b.toString(cc),
                                                  s);
                         goto Lthrow;
                     }
@@ -1818,7 +1822,7 @@ struct IR
                     if(!v)
                     {
                         ErrInfo errinfo;
-                        a = Dobject.ReferenceError(errmsgtbl[ERR_UNDEFINED_VAR],s);
+                        a = Dobject.ReferenceError(cc,errmsgtbl[ERR_UNDEFINED_VAR],s);
                         //a = Dobject.RuntimeError(&errinfo, errmsgtbl[ERR_UNDEFINED_NO_CALL2], "property", s);
                         goto Lthrow;
                     }
@@ -1837,14 +1841,15 @@ struct IR
                 case IRcallv:   // v(argc, argv) = a
                     a = GETa(code);
                     b = GETb(code);
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     if(!o)
                     {
                         //writef("%s %s is undefined and has no Call method\n", b.getType(), b.toString());
                         ErrInfo errinfo;
                         a = Dobject.RuntimeError(&errinfo,
+                                                 cc,
                                                  errmsgtbl[ERR_UNDEFINED_NO_CALL2],
-                                                 b.getType(), b.toString());
+                                                 b.getType(), b.toString(cc));
                         goto Lthrow;
                     }
                     cc.callerothis = othis;        // pass othis to eval()
@@ -1856,7 +1861,7 @@ struct IR
                     goto Lnext;
 
                 case IRputcall:        // b.c(argc, argv) = a
-                    s = GETc(code).toString();
+                    s = GETc(code).toString(cc);
                     goto case_putcall;
 
                 case IRputcalls:       //  b.s(argc, argv) = a
@@ -1866,7 +1871,7 @@ struct IR
                     case_putcall:
                     a = GETa(code);
                     b = GETb(code);
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     if(!o)
                         goto Lcallerror;
                     //v = o.GetLambda(s, Value.calcHash(s));
@@ -1874,16 +1879,17 @@ struct IR
                     if(!v)
                         goto Lcallerror;
                     //writef("calling... '%s'\n", v.toString());
-                    o = v.toObject();
+                    o = v.toObject(cc);
                     if(!o)
                     {
                         ErrInfo errinfo;
                         a = Dobject.RuntimeError(&errinfo,
+                                                 cc,
                                                  errmsgtbl[ERR_CANNOT_ASSIGN_TO2],
                                                  b.getType(), s);
                         goto Lthrow;
                     }
-                    a = cast(Value*)o.put_Value(a, GETe(code)[0 .. (code + 4).index]);
+                    a = cast(Value*)o.put_Value(cc, a, GETe(code)[0 .. (code + 4).index]);
                     if(a)
                         goto Lthrow;
                     code += 6;
@@ -1897,20 +1903,22 @@ struct IR
                     {
                         ErrInfo errinfo;
                         a = Dobject.RuntimeError(&errinfo,
+                                                 cc,
                                                  errmsgtbl[ERR_UNDEFINED_NO_CALL2],
                                                  "property", s);
                         goto Lthrow;
                     }
-                    o = v.toObject();
+                    o = v.toObject(cc);
                     if(!o)
                     {
                         ErrInfo errinfo;
                         a = Dobject.RuntimeError(&errinfo,
+                                                 cc,
                                                  errmsgtbl[ERR_CANNOT_ASSIGN_TO],
                                                  s);
                         goto Lthrow;
                     }
-                    a = cast(Value*)o.put_Value(GETa(code), GETd(code)[0 .. (code + 3).index]);
+                    a = cast(Value*)o.put_Value(cc, GETa(code), GETd(code)[0 .. (code + 3).index]);
                     if(a)
                         goto Lthrow;
                     code += 5;
@@ -1918,17 +1926,18 @@ struct IR
 
                 case IRputcallv:        // v(argc, argv) = a
                     b = GETb(code);
-                    o = b.toObject();
+                    o = b.toObject(cc);
                     if(!o)
                     {
                         //writef("%s %s is undefined and has no Call method\n", b.getType(), b.toString());
                         ErrInfo errinfo;
                         a = Dobject.RuntimeError(&errinfo,
+                                                 cc,
                                                  errmsgtbl[ERR_UNDEFINED_NO_CALL2],
-                                                 b.getType(), b.toString());
+                                                 b.getType(), b.toString(cc));
                         goto Lthrow;
                     }
-                    a = cast(Value*)o.put_Value(GETa(code), GETd(code)[0 .. (code + 3).index]);
+                    a = cast(Value*)o.put_Value(cc, GETa(code), GETd(code)[0 .. (code + 3).index]);
                     if(a)
                         goto Lthrow;
                     code += 5;
@@ -1949,10 +1958,10 @@ struct IR
                 case IRpush:
                     SCOPECACHE_CLEAR();
                     a = GETa(code);
-                    o = a.toObject();
+                    o = a.toObject(cc);
                     if(!o)
                     {
-                        a = cannotConvert(a, GETlinnum(code));
+                        a = cannotConvert(a, cc, GETlinnum(code));
                         goto Lthrow;
                     }
                     scopex ~= o;                // push entry onto scope chain
@@ -1991,14 +2000,14 @@ struct IR
 
                 case IRretexp:
                     a = GETa(code);
-                    a.checkReference();
+                    a.checkReference(cc);
                     Value.copy(ret, a);
                     //writef("returns: %s\n", ret.toString());
                     return null;
 
                 case IRimpret:
                     a = GETa(code);
-                    a.checkReference();
+                    a.checkReference(cc);
                     Value.copy(ret, a);
                     //writef("implicit return: %s\n", ret.toString());
                     code += 2;
@@ -2017,7 +2026,7 @@ struct IR
                     SCOPECACHE_CLEAR();
                     offset = cast(uint)(code - codestart) + (code + 1).offset;
                     s = (code + 2).id.value.string;
-                    ca = new Catch(offset, s);
+                    ca = new Catch(cc, offset, s);
                     scopex ~= ca;
                     cc.scopex = scopex;
                     code += 3;
@@ -2025,7 +2034,7 @@ struct IR
 
                 case IRtryfinally:
                     SCOPECACHE_CLEAR();
-                    f = new Finally(code + (code + 1).offset);
+                    f = new Finally(cc, code + (code + 1).offset);
                     scopex ~= f;
                     cc.scopex = scopex;
                     code += 2;
@@ -2037,7 +2046,7 @@ struct IR
                     errinfo.linnum = cast(uint)(code + 1).index;
                     version(all)  // Not supported under some com servers
                     {
-                        a = Dobject.RuntimeError(&errinfo, errmsgtbl[ERR_ASSERT], (code + 1).index);
+                        a = Dobject.RuntimeError(&errinfo, cc, errmsgtbl[ERR_ASSERT], (code + 1).index);
                         goto Lthrow;
                     }
                     else

--- a/engine/source/dmdscript/program.d
+++ b/engine/source/dmdscript/program.d
@@ -40,7 +40,7 @@ class Program
     uint errors;        // if any errors in file
     CallContext *callcontext;
     FunctionDefinition globalfunction;
-    static Program program;//per thread global associated data
+    bool threadInitTableRan = false;
 
     // Locale info
     uint lcid;          // current locale
@@ -62,12 +62,12 @@ class Program
         CallContext *cc = callcontext;
 
         // Do object inits
-        dobject_init();
+        dobject_init(cc);
 
         cc.prog = this;
 
         // Create global object
-        cc.global = new Dglobal(null);
+        cc.global = new Dglobal(cc, null);
 
         Dobject[] scopex;
         scopex ~= cc.global;
@@ -179,12 +179,12 @@ class Program
         //Program program_save;
 
         // Set argv and argc for execute
-        arguments = new Darray();
-        dglobal.Put(TEXT_arguments, arguments, DontDelete | DontEnum);
+        arguments = new Darray(cc);
+        dglobal.Put(cc, TEXT_arguments, arguments, DontDelete | DontEnum);
         arguments.length.putVnumber(args.length);
         for(int i = 0; i < args.length; i++)
         {
-            arguments.Put(i, args[i], DontEnum);
+            arguments.Put(cc, i, args[i], DontEnum);
         }
 
         Value[] p1;
@@ -204,23 +204,17 @@ class Program
 
         // Instantiate global variables as properties of global
         // object with 0 attributes
-        globalfunction.instantiate(cc.scopex, cc.variable, DontDelete);
+        globalfunction.instantiate(cc, cc.scopex, cc.variable, DontDelete);
 
 //	cc.scopex.reserve(globalfunction.withdepth + 1);
 
-        // The 'this' value is the global object
-        //FIXED: NOT any longer in D 2.0, any global data is actually thread-local, so stripped all this 'saving global object' crap
-        //printf("cc.scopex.ptr = %x, cc.scopex.length = %d\n", cc.scopex.ptr, cc.scopex.length);
-        //program_save = getProgram();
-
-        setProgram(this);
         ret.putVundefined();
         result = cast(Value*)IR.call(cc, cc.global, globalfunction.code, &ret, locals.ptr);
         if(result)
         {
             ErrInfo errinfo;
 
-            result.getErrInfo(&errinfo, cc.linnum);
+            result.getErrInfo(cc, &errinfo, cc.linnum);
             cc.linnum = 0;
             delete p1;
             throw new ScriptException(&errinfo);
@@ -235,23 +229,5 @@ class Program
     {
         if(globalfunction)
             globalfunction.toBuffer(buf);
-    }
-
-    /***********************************************
-     * Get/Set Program associated with this thread.
-     * This enables multiple scripts (Programs) running simultaneously
-     * in different threads.
-     * It is needed because which Program is being run is essentially
-     * global data - and this makes it thread local data.
-     */
-
-    static Program getProgram()
-    {
-        return program;
-    }
-
-    static void setProgram(Program p)
-    {
-        program = p;
     }
 }

--- a/engine/source/dmdscript/property.d
+++ b/engine/source/dmdscript/property.d
@@ -54,8 +54,16 @@ struct PropTable
 {
     RandAA!(Value, Property) table;
     PropTable* previous;
+    CallContext* callcontext;
 
-    int        opApply(int delegate(ref Property) dg)
+    @disable this();
+
+    this(CallContext* cc)
+    {
+        callcontext = cc;
+    }
+
+    int opApply(int delegate(ref Property) dg)
     {
         initialize();
         int result;
@@ -109,7 +117,7 @@ struct PropTable
         PropTable *t;
 
         //writefln("get(key = '%s', hash = x%x)", key.toString(), hash);
-        assert(key.toHash() == hash);
+        assert(key.toHash(null) == hash);
         t = &this;
         do
         {
@@ -310,7 +318,7 @@ struct PropTable
 
         v.putVstring(name);
 
-        return canput(&v, v.toHash());
+        return canput(&v, v.hashString());
     }
 
     int del(Value* key)
@@ -351,7 +359,7 @@ struct PropTable
     void initialize()
     {
         if(!table)
-            table = new RandAA!(Value, Property);
+            table = new RandAA!(Value, Property)(callcontext);
     }
 }
 

--- a/engine/source/dmdscript/protoerror.d
+++ b/engine/source/dmdscript/protoerror.d
@@ -31,11 +31,11 @@ import dmdscript.property;
 class D0_constructor : Dfunction
 {
     d_string text_d1;
-    Dobject function(d_string) newD0;
+    Dobject function(CallContext* cc, d_string) newD0;
 
-    this(d_string text_d1, Dobject function(d_string) newD0)
+    this(CallContext* cc, d_string text_d1, Dobject function(CallContext* cc, d_string) newD0)
     {
-        super(1, Dfunction_prototype);
+        super(cc, 1, Dfunction_prototype);
         this.text_d1 = text_d1;
         this.newD0 = newD0;
     }
@@ -52,8 +52,8 @@ class D0_constructor : Dfunction
         if(m.isUndefined())
             s = text_d1;
         else
-            s = m.toString();
-        o = (*newD0)(s);
+            s = m.toString(cc);
+        o = (*newD0)(cc, s);
         ret.putVobject(o);
         return null;
     }
@@ -72,18 +72,18 @@ template proto(alias TEXT_D1)
 
     class D0_prototype : D0
     {
-        this()
+        this(CallContext* cc)
         {
-            super(Derror_prototype);
+            super(cc, Derror_prototype);
 
             d_string s;
 
-            Put(TEXT_constructor, ctorTable[TEXT_D1], DontEnum);
-            Put(TEXT_name, TEXT_D1, 0);
+            Put(cc, TEXT_constructor, ctorTable[TEXT_D1], DontEnum);
+            Put(cc, TEXT_name, TEXT_D1, 0);
             s = TEXT_D1 ~ ".prototype.message";
-            Put(TEXT_message, s, 0);
-            Put(TEXT_description, s, 0);
-            Put(TEXT_number, cast(d_number)0, 0);
+            Put(cc, TEXT_message, s, 0);
+            Put(cc, TEXT_description, s, 0);
+            Put(cc, TEXT_number, cast(d_number)0, 0);
         }
     }
 
@@ -93,29 +93,29 @@ template proto(alias TEXT_D1)
     {
         ErrInfo errinfo;
 
-        this(Dobject prototype)
+        this(CallContext* cc, Dobject prototype)
         {
-            super(prototype);
+            super(cc, prototype);
             classname = TEXT_Error;
         }
 
-        this(d_string m)
+        this(CallContext* cc, d_string m)
         {
-            this(D0.getPrototype());
-            Put(TEXT_message, m, 0);
-            Put(TEXT_description, m, 0);
-            Put(TEXT_number, cast(d_number)0, 0);
+            this(cc, D0.getPrototype());
+            Put(cc, TEXT_message, m, 0);
+            Put(cc, TEXT_description, m, 0);
+            Put(cc, TEXT_number, cast(d_number)0, 0);
             errinfo.message = m;
         }
 
-        this(ErrInfo * perrinfo)
+        this(CallContext* cc, ErrInfo * perrinfo)
         {
-            this(perrinfo.message);
+            this(cc, perrinfo.message);
             errinfo = *perrinfo;
-            Put(TEXT_number, cast(d_number)perrinfo.code, 0);
+            Put(cc, TEXT_number, cast(d_number)perrinfo.code, 0);
         }
 
-        override void getErrInfo(ErrInfo *perrinfo, int linnum)
+        override void getErrInfo(CallContext* cc, ErrInfo *perrinfo, int linnum)
         {
             if(linnum && errinfo.linnum == 0)
                 errinfo.linnum = linnum;
@@ -134,20 +134,20 @@ template proto(alias TEXT_D1)
             return protoTable[TEXT_D1];
         }
 
-        static Dobject newD0(d_string s)
+        static Dobject newD0(CallContext* cc, d_string s)
         {
-            return new D0(s);
+            return new D0(cc, s);
         }
 
-        static void init()
+        static void init(CallContext* cc)
         {
-            Dfunction constructor = new D0_constructor(TEXT_D1, &newD0);
+            Dfunction constructor = new D0_constructor(cc, TEXT_D1, &newD0);
             ctorTable[TEXT_D1] = constructor;
 
-            Dobject prototype = new D0_prototype();
+            Dobject prototype = new D0_prototype(cc);
             protoTable[TEXT_D1] = prototype;
 
-            constructor.Put(TEXT_prototype, prototype, DontEnum | DontDelete | ReadOnly);
+            constructor.Put(cc, TEXT_prototype, prototype, DontEnum | DontDelete | ReadOnly);
         }
     }
 }
@@ -165,10 +165,12 @@ alias proto!(TEXT_URIError) urierror;
 
 static this()
 {
-    threadInitTable ~= &syntaxerror.D0.init;
-    threadInitTable ~= &evalerror.D0.init;
-    threadInitTable ~= &referenceerror.D0.init;
-    threadInitTable ~= &rangeerror.D0.init;
-    threadInitTable ~= &typeerror.D0.init;
-    threadInitTable ~= &urierror.D0.init;
+    import std.functional : toDelegate;
+
+    threadInitTable ~= toDelegate(&syntaxerror.D0.init);
+    threadInitTable ~= toDelegate(&evalerror.D0.init);
+    threadInitTable ~= toDelegate(&referenceerror.D0.init);
+    threadInitTable ~= toDelegate(&rangeerror.D0.init);
+    threadInitTable ~= toDelegate(&typeerror.D0.init);
+    threadInitTable ~= toDelegate(&urierror.D0.init);
 }

--- a/engine/source/dmdscript/threadcontext.d
+++ b/engine/source/dmdscript/threadcontext.d
@@ -63,4 +63,5 @@ Dobject Denumerator_prototype;
 
 Dmath Dmath_object;
 
-void function ()[] threadInitTable;
+// kept for backwards compatibility with the dmdscript.extending module
+void delegate (CallContext*)[] threadInitTable;

--- a/engine/source/dmdscript/value.d
+++ b/engine/source/dmdscript/value.d
@@ -78,12 +78,12 @@ struct Value
 
         Iterator* iter;         // V_ITER
     }
-    void checkReference(){
+    void checkReference(CallContext* cc){
         if(vtype == V_REF_ERROR)
-            throwRefError();
+            throwRefError(cc);
     }
-    void throwRefError() const{
-        throw new ErrorValue(Dobject.ReferenceError(errmsgtbl[ERR_UNDEFINED_VAR],string));
+    void throwRefError(CallContext* cc) const{
+        throw new ErrorValue(Dobject.ReferenceError(cc,errmsgtbl[ERR_UNDEFINED_VAR],string));
     }
     
     void putSignalingUndefined(d_string id){
@@ -208,7 +208,7 @@ struct Value
         }
     }
 
-    void* toPrimitive(Value* v, d_string PreferredType)
+    void* toPrimitive(CallContext* cc, Value* v, d_string PreferredType)
     {
         if(vtype == V_OBJECT)
         {
@@ -226,7 +226,7 @@ struct Value
             void* a;
 
             assert(object);
-            a = object.DefaultValue(v, PreferredType);
+            a = object.DefaultValue(cc, v, PreferredType);
             if(a)
                 throw new ErrorValue(cast(Value*)a);
             if(!v.isPrimitive())
@@ -234,7 +234,7 @@ struct Value
                 ErrInfo errinfo;
 
                 v.putVundefined();
-                throw new ErrorValue(Dobject.RuntimeError(&errinfo, errmsgtbl[ERR_OBJECT_CANNOT_BE_PRIMITIVE]));
+                throw new ErrorValue(Dobject.RuntimeError(&errinfo, cc, errmsgtbl[ERR_OBJECT_CANNOT_BE_PRIMITIVE]));
             }
         }
         else
@@ -245,12 +245,12 @@ struct Value
     }
 
 
-    d_boolean toBoolean()
+    d_boolean toBoolean(CallContext* cc)
     {
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
         case V_NULL:
@@ -270,12 +270,12 @@ struct Value
     }
 
 
-    d_number toNumber()
+    d_number toNumber(CallContext* cc)
     {
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
             return d_number.nan;
@@ -314,11 +314,11 @@ struct Value
 
           //writefln("Vobject.toNumber()");
           v = &val;
-          a = toPrimitive(v, TypeNumber);
+          a = toPrimitive(cc, v, TypeNumber);
           /*if(a)//rerr
                   return d_number.nan;*/
           if(v.isPrimitive())
-              return v.toNumber();
+              return v.toNumber(cc);
           else
               return d_number.nan;
         }
@@ -329,18 +329,18 @@ struct Value
     }
 
 
-    d_time toDtime()
+    d_time toDtime(CallContext* cc)
     {
-        return cast(d_time)toNumber();
+        return cast(d_time)toNumber(cc);
     }
 
 
-    d_number toInteger()
+    d_number toInteger(CallContext* cc)
     {
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
             return d_number.nan;
@@ -352,7 +352,7 @@ struct Value
         default:
         { d_number number;
 
-          number = toNumber();
+          number = toNumber(cc);
           if(isNaN(number))
               number = 0;
           else if(number == 0 || std.math.isInfinity(number))
@@ -368,12 +368,12 @@ struct Value
     }
 
 
-    d_int32 toInt32()
+    d_int32 toInt32(CallContext* cc)
     {
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
         case V_NULL:
@@ -386,7 +386,7 @@ struct Value
           d_number number;
           long ll;
 
-          number = toNumber();
+          number = toNumber(cc);
           if(isNaN(number))
               int32 = 0;
           else if(number == 0 || std.math.isInfinity(number))
@@ -407,12 +407,12 @@ struct Value
     }
 
 
-    d_uint32 toUint32()
+    d_uint32 toUint32(CallContext* cc)
     {
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
         case V_NULL:
@@ -425,7 +425,7 @@ struct Value
           d_number number;
           long ll;
 
-          number = toNumber();
+          number = toNumber(cc);
           if(isNaN(number))
               uint32 = 0;
           else if(number == 0 || std.math.isInfinity(number))
@@ -445,12 +445,12 @@ struct Value
         assert(0);
     }
 
-    d_uint16 toUint16()
+    d_uint16 toUint16(CallContext* cc)
     {
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
         case V_NULL:
@@ -462,7 +462,7 @@ struct Value
         { d_uint16 uint16;
           d_number number;
 
-          number = toNumber();
+          number = toNumber(cc);
           if(isNaN(number))
               uint16 = 0;
           else if(number == 0 || std.math.isInfinity(number))
@@ -481,12 +481,12 @@ struct Value
         assert(0);
     }
 
-    d_string toString()
+    d_string toString(CallContext* cc)
     {
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
             return TEXT_undefined;
@@ -573,12 +573,12 @@ struct Value
           void* a;
 
           //writef("Vobject.toString()\n");
-          a = toPrimitive(v, TypeString);
+          a = toPrimitive(cc, v, TypeString);
           //assert(!a);
           if(v.isPrimitive())
-              return v.toString();
+              return v.toString(cc);
           else
-              return v.toObject().classname;
+              return v.toObject(cc).classname;
         }
         default:
             assert(0);
@@ -586,12 +586,12 @@ struct Value
         assert(0);
     }
 
-    d_string toLocaleString()
+    d_string toLocaleString(CallContext* cc)
     {
-        return toString();
+        return toString(cc);
     }
 
-    d_string toString(int radix)
+    d_string toString(CallContext* cc, int radix)
     {
         import std.conv : to;
 
@@ -599,16 +599,16 @@ struct Value
         {
             assert(2 <= radix && radix <= 36);
             if(!isFinite(number))
-                return toString();
+                return toString(cc);
             return number >= 0.0 ? to!(d_string)(cast(long)number, radix) : "-"~to!(d_string)(cast(long)-number,radix);
         }
         else
         {
-            return toString();
+            return toString(cc);
         }
     }
 
-    d_string toSource()
+    d_string toSource(CallContext* cc)
     {
         switch(vtype)
         {
@@ -621,21 +621,19 @@ struct Value
         { Value* v;
 
           //writefln("Vobject.toSource()");
-          v = Get(TEXT_toSource);
+          v = Get(cc, TEXT_toSource);
           if(!v)
               v = &vundefined;
           if(v.isPrimitive())
-              return v.toSource();
+              return v.toSource(cc);
           else          // it's an Object
           {
               void* a;
-              CallContext *cc;
               Dobject o;
               Value* ret;
               Value val;
 
               o = v.object;
-              cc = Program.getProgram().callcontext;
               ret = &val;
               a = o.Call(cc, this.object, ret, null);
               if(a)                             // if exception was thrown
@@ -644,21 +642,21 @@ struct Value
                   writef("Vobject.toSource() failed with %x\n", a);
               }
               else if(ret.isPrimitive())
-                  return ret.toString();
+                  return ret.toString(cc);
           }
           return TEXT_undefined; }
         default:
-            return toString();
+            return toString(cc);
         }
         assert(0);
     }
 
-    Dobject toObject()
+    Dobject toObject(CallContext* cc)
     {
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
             //RuntimeErrorx("cannot convert undefined to Object");
@@ -667,11 +665,11 @@ struct Value
             //RuntimeErrorx("cannot convert null to Object");
             return null;
         case V_BOOLEAN:
-            return new Dboolean(dbool);
+            return new Dboolean(cc, dbool);
         case V_NUMBER:
-            return new Dnumber(number);
+            return new Dnumber(cc, number);
         case V_STRING:
-            return new Dstring(string);
+            return new Dstring(cc, string);
         case V_OBJECT:
             return object;
         default:
@@ -680,9 +678,11 @@ struct Value
         assert(0);
     }
 
-    const bool opEquals(ref const (Value)v)
+    @disable bool opEquals(ref const(Value) v) const { assert(false); }
+
+    const bool isEqual(CallContext* cc, ref const (Value)v)
     {
-        return(opCmp(v) == 0);
+        return compare(cc, v) == 0;
     }
 
     /*********************************
@@ -703,12 +703,14 @@ struct Value
         return cast(int)c;
     }
 
-    int opCmp(const (Value)v) const
+    @disable int opCmp(const(Value) v) const { assert(false); }
+
+    int compare(CallContext* cc, const (Value)v) const
     {
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
             if(vtype == v.vtype)
@@ -734,7 +736,7 @@ struct Value
             }
             else if(v.vtype == V_STRING)
             {
-                return stringcmp((cast(Value*)&this).toString(), v.string);    //TODO: remove this hack!
+                return stringcmp((cast(Value*)&this).toString(cc), v.string);    //TODO: remove this hack!
             }
             break;
         case V_STRING:
@@ -753,7 +755,7 @@ struct Value
             else if(v.vtype == V_NUMBER)
             {
                 //writefln("'%s'.compareTo(%g)\n", string, v.number);
-                return stringcmp(string, (cast(Value*)&v).toString());    //TODO: remove this hack!
+                return stringcmp(string, (cast(Value*)&v).toString(cc));    //TODO: remove this hack!
             }
             break;
         case V_OBJECT:
@@ -850,12 +852,12 @@ struct Value
         return vtype != V_OBJECT;
     }
 
-    int isArrayIndex(out d_uint32 index)
+    int isArrayIndex(CallContext* cc, out d_uint32 index)
     {
         switch(vtype)
         {
         case V_NUMBER:
-            index = toUint32();
+            index = toUint32(cc);
             return true;
         case V_STRING:
             return StringToIndex(string, index);
@@ -947,14 +949,27 @@ struct Value
         return calcHash(hash);
     }
 
-    uint toHash()
+    @disable uint toHash();
+
+    uint hashString()
+    {
+        assert(vtype == V_STRING);
+
+        // Since strings are immutable, if we've already
+        // computed the hash, use previous value
+        if(!hash)
+            hash = calcHash(string);
+        return hash;
+    }
+
+    uint toHash(CallContext* cc)
     {
         uint h;
 
         switch(vtype)
         {
         case V_REF_ERROR:
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         case V_UNDEFINED:
         case V_NULL:
@@ -967,11 +982,7 @@ struct Value
             h = calcHash(number);
             break;
         case V_STRING:
-            // Since strings are immutable, if we've already
-            // computed the hash, use previous value
-            if(!hash)
-                hash = calcHash(string);
-            h = hash;
+            h = hashString();
             break;
         case V_OBJECT:
             /* Uses the address of the object as the hash.
@@ -988,37 +999,39 @@ struct Value
         return h;
     }
 
-    Value* Put(d_string PropertyName, Value* value)
+    Value* Put(CallContext* cc, d_string PropertyName, Value* value)
     {
         if(vtype == V_OBJECT)
-            return object.Put(PropertyName, value, 0);
+            return object.Put(cc, PropertyName, value, 0);
         else
         {
             ErrInfo errinfo;
 
             return Dobject.RuntimeError(&errinfo,
+                                        cc,
                                         errmsgtbl[ERR_CANNOT_PUT_TO_PRIMITIVE],
-                                        PropertyName, value.toString(),
+                                        PropertyName, value.toString(cc),
                                         getType());
         }
     }
 
-    Value* Put(d_uint32 index, Value* vindex, Value* value)
+    Value* Put(CallContext* cc, d_uint32 index, Value* vindex, Value* value)
     {
         if(vtype == V_OBJECT)
-            return object.Put(index, vindex, value, 0);
+            return object.Put(cc, index, vindex, value, 0);
         else
         {
             ErrInfo errinfo;
 
             return Dobject.RuntimeError(&errinfo,
+                                        cc,
                                         errmsgtbl[ERR_CANNOT_PUT_INDEX_TO_PRIMITIVE],
                                         index,
-                                        value.toString(), getType());
+                                        value.toString(cc), getType());
         }
     }
 
-    Value* Get(d_string PropertyName)
+    Value* Get(CallContext* cc, d_string PropertyName)
     {
         if(vtype == V_OBJECT)
             return object.Get(PropertyName);
@@ -1028,13 +1041,13 @@ struct Value
             d_string msg;
 
             msg = std.string.format(errmsgtbl[ERR_CANNOT_GET_FROM_PRIMITIVE],
-                                    PropertyName, getType(), toString());
+                                    PropertyName, getType(), toString(cc));
             throw new ScriptException(msg);
             //return &vundefined;
         }
     }
 
-    Value* Get(d_uint32 index)
+    Value* Get(CallContext* cc,d_uint32 index)
     {
         if(vtype == V_OBJECT)
             return object.Get(index);
@@ -1044,18 +1057,18 @@ struct Value
             d_string msg;
 
             msg = std.string.format(errmsgtbl[ERR_CANNOT_GET_INDEX_FROM_PRIMITIVE],
-                                    index, getType(), toString());
+                                    index, getType(), toString(cc));
             throw new ScriptException(msg);
             //return &vundefined;
         }
     }
 
-    Value* Get(Identifier *id)
+    Value* Get(CallContext* cc,Identifier *id)
     {
         if(vtype == V_OBJECT)
             return object.Get(id);
         else if(vtype == V_REF_ERROR){
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         }
         else
@@ -1064,7 +1077,7 @@ struct Value
             d_string msg;
 
             msg = std.string.format(errmsgtbl[ERR_CANNOT_GET_FROM_PRIMITIVE],
-                                    id.toString(), getType(), toString());
+                                    id.toString(), getType(), toString(cc));
             throw new ScriptException(msg);
             //return &vundefined;
         }
@@ -1091,14 +1104,14 @@ struct Value
         if(vtype == V_OBJECT)
             return object.Construct(cc, ret, arglist);
         else if(vtype == V_REF_ERROR){
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         }
         else
         {
             ErrInfo errinfo;
             ret.putVundefined();
-            return Dobject.RuntimeError(&errinfo,
+            return Dobject.RuntimeError(&errinfo, cc,
                                         errmsgtbl[ERR_PRIMITIVE_NO_CONSTRUCT], getType());
         }
     }
@@ -1114,7 +1127,7 @@ struct Value
             return a;
         }
         else if(vtype == V_REF_ERROR){
-            throwRefError();
+            throwRefError(cc);
             assert(0);
         }
         else
@@ -1122,36 +1135,36 @@ struct Value
             ErrInfo errinfo;
             //PRINTF("Call method not implemented for primitive %p (%s)\n", this, d_string_ptr(toString()));
             ret.putVundefined();
-            return Dobject.RuntimeError(&errinfo,
+            return Dobject.RuntimeError(&errinfo, cc,
                                         errmsgtbl[ERR_PRIMITIVE_NO_CALL], getType());
         }
     }
 
-    Value* putIterator(Value* v)
+    Value* putIterator(CallContext* cc, Value* v)
     {
         if(vtype == V_OBJECT)
-            return object.putIterator(v);
+            return object.putIterator(cc, v);
         else
         {
             ErrInfo errinfo;
             v.putVundefined();
-            return Dobject.RuntimeError(&errinfo,
+            return Dobject.RuntimeError(&errinfo, cc,
                                         errmsgtbl[ERR_FOR_IN_MUST_BE_OBJECT]);
         }
     }
 
 
-    void getErrInfo(ErrInfo *perrinfo, int linnum)
+    void getErrInfo(CallContext* cc, ErrInfo *perrinfo, int linnum)
     {
         if(vtype == V_OBJECT)
-            object.getErrInfo(perrinfo, linnum);
+            object.getErrInfo(cc, perrinfo, linnum);
         else
         {
             ErrInfo errinfo;
 
             if(linnum && errinfo.linnum == 0)
                 errinfo.linnum = linnum;
-            errinfo.message = "Unhandled exception: " ~ toString();
+            errinfo.message = "Unhandled exception: " ~ toString(cc);
             if(perrinfo)
                 *perrinfo = errinfo;
         }


### PR DESCRIPTION
This instead passes the call context as a parameter everywhere except for `PropTable` and `RandAA` where this was impractical. The context is passed as the second parameter (first parameter for methods), so that it can usually stay within the same register.