### PR TITLE
Move globals in threadcontext into a struct contained in CallContext.

### DIFF
--- a/engine/source/dmdscript/darguments.d
+++ b/engine/source/dmdscript/darguments.d
@@ -45,7 +45,7 @@ class Darguments : Dobject
          Identifier *[] parameters, Value[] arglist)
 
     {
-        super(cc, Dobject.getPrototype());
+        super(cc, Dobject.getPrototype(cc));
 
         this.actobj = actobj;
         this.parameters = parameters;

--- a/engine/source/dmdscript/darray.d
+++ b/engine/source/dmdscript/darray.d
@@ -44,7 +44,7 @@ class DarrayConstructor : Dfunction
 {
     this(CallContext* cc)
     {
-        super(cc, 1, Dfunction_prototype);
+        super(cc, 1, cc.tc.Dfunction_prototype);
         name = "Array";
     }
 
@@ -951,10 +951,10 @@ class DarrayPrototype : Darray
 {
     this(CallContext* cc)
     {
-        super(cc, Dobject_prototype);
-        Dobject f = Dfunction_prototype;
+        super(cc, cc.tc.Dobject_prototype);
+        Dobject f = cc.tc.Dfunction_prototype;
 
-        Put(cc, TEXT_constructor, Darray_constructor, DontEnum);
+        Put(cc, TEXT_constructor, cc.tc.Darray_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -987,7 +987,7 @@ class Darray : Dobject
 
     this(CallContext* cc)
     {
-        this(cc, getPrototype());
+        this(cc, getPrototype(cc));
     }
 
     this(CallContext* cc, Dobject prototype)
@@ -1193,22 +1193,22 @@ class Darray : Dobject
     }
 
 
-    static Dfunction getConstructor()
+    static Dfunction getConstructor(CallContext* cc)
     {
-        return Darray_constructor;
+        return cc.tc.Darray_constructor;
     }
 
-    static Dobject getPrototype()
+    static Dobject getPrototype(CallContext* cc)
     {
-        return Darray_prototype;
+        return cc.tc.Darray_prototype;
     }
 
     static void initialize(CallContext* cc)
     {
-        Darray_constructor = new DarrayConstructor(cc);
-        Darray_prototype = new DarrayPrototype(cc);
+        cc.tc.Darray_constructor = new DarrayConstructor(cc);
+        cc.tc.Darray_prototype = new DarrayPrototype(cc);
 
-        Darray_constructor.Put(cc, TEXT_prototype, Darray_prototype, DontEnum |  ReadOnly);
+        cc.tc.Darray_constructor.Put(cc, TEXT_prototype, cc.tc.Darray_prototype, DontEnum |  ReadOnly);
     }
 }
 

--- a/engine/source/dmdscript/dboolean.d
+++ b/engine/source/dmdscript/dboolean.d
@@ -33,7 +33,7 @@ class DbooleanConstructor : Dfunction
 {
     this(CallContext* cc)
     {
-        super(cc, 1, Dfunction_prototype);
+        super(cc, 1, cc.tc.Dfunction_prototype);
         name = "Boolean";
     }
 
@@ -118,10 +118,10 @@ class DbooleanPrototype : Dboolean
 {
     this(CallContext* cc)
     {
-        super(cc, Dobject_prototype);
+        super(cc, cc.tc.Dobject_prototype);
         //Dobject f = Dfunction_prototype;
 
-        Put(cc, TEXT_constructor, Dboolean_constructor, DontEnum);
+        Put(cc, TEXT_constructor, cc.tc.Dboolean_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -140,7 +140,7 @@ class Dboolean : Dobject
 {
     this(CallContext* cc, d_boolean b)
     {
-        super(cc, Dboolean.getPrototype());
+        super(cc, Dboolean.getPrototype(cc));
         value.putVboolean(b);
         classname = TEXT_Boolean;
     }
@@ -152,22 +152,22 @@ class Dboolean : Dobject
         classname = TEXT_Boolean;
     }
 
-    static Dfunction getConstructor()
+    static Dfunction getConstructor(CallContext* cc)
     {
-        return Dboolean_constructor;
+        return cc.tc.Dboolean_constructor;
     }
 
-    static Dobject getPrototype()
+    static Dobject getPrototype(CallContext* cc)
     {
-        return Dboolean_prototype;
+        return cc.tc.Dboolean_prototype;
     }
 
     static void initialize(CallContext* cc)
     {
-        Dboolean_constructor = new DbooleanConstructor(cc);
-        Dboolean_prototype = new DbooleanPrototype(cc);
+        cc.tc.Dboolean_constructor = new DbooleanConstructor(cc);
+        cc.tc.Dboolean_prototype = new DbooleanPrototype(cc);
 
-        Dboolean_constructor.Put(cc, TEXT_prototype, Dboolean_prototype, DontEnum | DontDelete | ReadOnly);
+        cc.tc.Dboolean_constructor.Put(cc, TEXT_prototype, cc.tc.Dboolean_prototype, DontEnum | DontDelete | ReadOnly);
     }
 }
 

--- a/engine/source/dmdscript/ddate.d
+++ b/engine/source/dmdscript/ddate.d
@@ -189,7 +189,7 @@ class DdateConstructor : Dfunction
 {
     this(CallContext* cc)
     {
-        super(cc, 7, Dfunction_prototype);
+        super(cc, 7, cc.tc.Dfunction_prototype);
         name = "Date";
 
         static enum NativeFunctionData[] nfd =
@@ -1442,11 +1442,11 @@ class DdatePrototype : Ddate
 {
     this(CallContext* cc)
     {
-        super(cc, Dobject_prototype);
+        super(cc, cc.tc.Dobject_prototype);
 
-        Dobject f = Dfunction_prototype;
+        Dobject f = cc.tc.Dfunction_prototype;
 
-        Put(cc, TEXT_constructor, Ddate_constructor, DontEnum);
+        Put(cc, TEXT_constructor, cc.tc.Ddate_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -1511,14 +1511,14 @@ class Ddate : Dobject
 {
     this(CallContext* cc, d_number n)
     {
-        super(cc, Ddate.getPrototype());
+        super(cc, Ddate.getPrototype(cc));
         classname = TEXT_Date;
         value.putVnumber(n);
     }
 
     this(CallContext* cc, d_time n)
     {
-        super(cc, Ddate.getPrototype());
+        super(cc, Ddate.getPrototype(cc));
         classname = TEXT_Date;
         value.putVtime(n);
     }
@@ -1532,23 +1532,23 @@ class Ddate : Dobject
 
     static void initialize(CallContext* cc)
     {
-        Ddate_constructor = new DdateConstructor(cc);
-        Ddate_prototype = new DdatePrototype(cc);
+        cc.tc.Ddate_constructor = new DdateConstructor(cc);
+        cc.tc.Ddate_prototype = new DdatePrototype(cc);
 
-        Ddate_constructor.Put(cc, TEXT_prototype, Ddate_prototype,
+        cc.tc.Ddate_constructor.Put(cc, TEXT_prototype, cc.tc.Ddate_prototype,
                                  DontEnum | DontDelete | ReadOnly);
 
-        assert(Ddate_prototype.proptable.table.length != 0);
+        assert(cc.tc.Ddate_prototype.proptable.table.length != 0);
     }
 
-    static Dfunction getConstructor()
+    static Dfunction getConstructor(CallContext* cc)
     {
-        return Ddate_constructor;
+        return cc.tc.Ddate_constructor;
     }
 
-    static Dobject getPrototype()
+    static Dobject getPrototype(CallContext* cc)
     {
-        return Ddate_prototype;
+        return cc.tc.Ddate_prototype;
     }
 }
 

--- a/engine/source/dmdscript/ddeclaredfunction.d
+++ b/engine/source/dmdscript/ddeclaredfunction.d
@@ -40,15 +40,15 @@ class DdeclaredFunction : Dfunction
 
     this(CallContext* cc, FunctionDefinition fd)
     {
-        super(cc, cast(uint)fd.parameters.length, Dfunction.getPrototype());
-        assert(Dfunction.getPrototype());
+        super(cc, cast(uint)fd.parameters.length, Dfunction.getPrototype(cc));
+        assert(Dfunction.getPrototype(cc));
         assert(internal_prototype);
         this.fd = fd;
 
         Dobject o;
 
         // ECMA 3 13.2
-        o = new Dobject(cc, Dobject.getPrototype());        // step 9
+        o = new Dobject(cc, Dobject.getPrototype(cc));        // step 9
         Put(cc, TEXT_prototype, o, DontEnum);               // step 11
         o.Put(cc, TEXT_constructor, this, DontEnum);        // step 10
     }
@@ -193,7 +193,7 @@ class DdeclaredFunction : Dfunction
 
         v = Get(TEXT_prototype);
         if(v.isPrimitive())
-            proto = Dobject.getPrototype();
+            proto = Dobject.getPrototype(cc);
         else
             proto = v.toObject(cc);
         othis = new Dobject(cc, proto);

--- a/engine/source/dmdscript/derror.d
+++ b/engine/source/dmdscript/derror.d
@@ -36,7 +36,7 @@ class DerrorConstructor : Dfunction
 {
     this(CallContext* cc)
     {
-        super(cc, 1, Dfunction_prototype);
+        super(cc, 1, cc.tc.Dfunction_prototype);
     }
 
     override void* Construct(CallContext *cc, Value *ret, Value[] arglist)
@@ -104,11 +104,11 @@ class DerrorPrototype : Derror
 {
     this(CallContext* cc)
     {
-        super(cc, Dobject_prototype);
-        Dobject f = Dfunction_prototype;
+        super(cc, cc.tc.Dobject_prototype);
+        Dobject f = cc.tc.Dfunction_prototype;
         //d_string m = d_string_ctor(DTEXT("Error.prototype.message"));
 
-        Put(cc, TEXT_constructor, Derror_constructor, DontEnum);
+        Put(cc, TEXT_constructor, cc.tc.Derror_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -131,7 +131,7 @@ class Derror : Dobject
 {
     this(CallContext* cc, Value * m, Value * v2)
     {
-        super(cc, getPrototype());
+        super(cc, getPrototype(cc));
         classname = TEXT_Error;
 
         immutable(char)[] msg;
@@ -166,22 +166,22 @@ class Derror : Dobject
         classname = TEXT_Error;
     }
 
-    static Dfunction getConstructor()
+    static Dfunction getConstructor(CallContext* cc)
     {
-        return Derror_constructor;
+        return cc.tc.Derror_constructor;
     }
 
-    static Dobject getPrototype()
+    static Dobject getPrototype(CallContext* cc)
     {
-        return Derror_prototype;
+        return cc.tc.Derror_prototype;
     }
 
     static void initialize(CallContext* cc)
     {
-        Derror_constructor = new DerrorConstructor(cc);
-        Derror_prototype = new DerrorPrototype(cc);
+        cc.tc.Derror_constructor = new DerrorConstructor(cc);
+        cc.tc.Derror_prototype = new DerrorPrototype(cc);
 
-        Derror_constructor.Put(cc, TEXT_prototype, Derror_prototype, DontEnum | DontDelete | ReadOnly);
+        cc.tc.Derror_constructor.Put(cc, TEXT_prototype, cc.tc.Derror_prototype, DontEnum | DontDelete | ReadOnly);
     }
 }
 

--- a/engine/source/dmdscript/dfunction.d
+++ b/engine/source/dmdscript/dfunction.d
@@ -41,7 +41,7 @@ class DfunctionConstructor : Dfunction
 {
     this(CallContext* cc)
     {
-        super(cc, 1, Dfunction_prototype);
+        super(cc, 1, cc.tc.Dfunction_prototype);
 
         // Actually put in later by Dfunction::initialize()
         //unsigned attributes = DontEnum | DontDelete | ReadOnly;
@@ -261,13 +261,13 @@ class DfunctionPrototype : Dfunction
 {
     this(CallContext* cc)
     {
-        super(cc, 0, Dobject_prototype);
+        super(cc, 0, cc.tc.Dobject_prototype);
 
         uint attributes = DontEnum;
 
         classname = TEXT_Function;
         name = "prototype";
-        Put(cc, TEXT_constructor, Dfunction_constructor, attributes);
+        Put(cc, TEXT_constructor, cc.tc.Dfunction_constructor, attributes);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -297,7 +297,7 @@ class Dfunction : Dobject
 
   this(CallContext* cc, d_uint32 length)
   {
-      this(cc, length, Dfunction.getPrototype());
+      this(cc, length, Dfunction.getPrototype(cc));
   }
 
   this(CallContext* cc, d_uint32 length, Dobject prototype)
@@ -375,24 +375,24 @@ class Dfunction : Dobject
   }
 
 
-  static Dfunction getConstructor()
+  static Dfunction getConstructor(CallContext* cc)
   {
-      return Dfunction_constructor;
+      return cc.tc.Dfunction_constructor;
   }
 
-  static Dobject getPrototype()
+  static Dobject getPrototype(CallContext* cc)
   {
-      return Dfunction_prototype;
+      return cc.tc.Dfunction_prototype;
   }
 
   static void initialize(CallContext* cc)
   {
-      Dfunction_constructor = new DfunctionConstructor(cc);
-      Dfunction_prototype = new DfunctionPrototype(cc);
+      cc.tc.Dfunction_constructor = new DfunctionConstructor(cc);
+      cc.tc.Dfunction_prototype = new DfunctionPrototype(cc);
 
-      Dfunction_constructor.Put(cc, TEXT_prototype, Dfunction_prototype, DontEnum | DontDelete | ReadOnly);
+      cc.tc.Dfunction_constructor.Put(cc, TEXT_prototype, cc.tc.Dfunction_prototype, DontEnum | DontDelete | ReadOnly);
 
-      Dfunction_constructor.internal_prototype = Dfunction_prototype;
-      Dfunction_constructor.proptable.previous = Dfunction_prototype.proptable;
+      cc.tc.Dfunction_constructor.internal_prototype = cc.tc.Dfunction_prototype;
+      cc.tc.Dfunction_constructor.proptable.previous = cc.tc.Dfunction_prototype.proptable;
   }
 }

--- a/engine/source/dmdscript/dglobal.d
+++ b/engine/source/dmdscript/dglobal.d
@@ -732,11 +732,11 @@ class Dglobal : Dobject
 {
     this(CallContext* cc, tchar[][] argv)
     {
-        super(cc, Dobject.getPrototype());  // Dglobal.prototype is implementation-dependent
+        super(cc, Dobject.getPrototype(cc));  // Dglobal.prototype is implementation-dependent
 
         //writef("Dglobal.Dglobal(%x)\n", this);
 
-        Dobject f = Dfunction.getPrototype();
+        Dobject f = Dfunction.getPrototype(cc);
 
         classname = TEXT_global;
 
@@ -783,25 +783,25 @@ class Dglobal : Dobject
 
         // Constructor properties
 
-        Put(cc, TEXT_Object, Dobject_constructor, DontEnum);
-        Put(cc, TEXT_Function, Dfunction_constructor, DontEnum);
-        Put(cc, TEXT_Array, Darray_constructor, DontEnum);
-        Put(cc, TEXT_String, Dstring_constructor, DontEnum);
-        Put(cc, TEXT_Boolean, Dboolean_constructor, DontEnum);
-        Put(cc, TEXT_Number, Dnumber_constructor, DontEnum);
-        Put(cc, TEXT_Date, Ddate_constructor, DontEnum);
-        Put(cc, TEXT_RegExp, Dregexp_constructor, DontEnum);
-        Put(cc, TEXT_Error, Derror_constructor, DontEnum);
+        Put(cc, TEXT_Object, cc.tc.Dobject_constructor, DontEnum);
+        Put(cc, TEXT_Function, cc.tc.Dfunction_constructor, DontEnum);
+        Put(cc, TEXT_Array, cc.tc.Darray_constructor, DontEnum);
+        Put(cc, TEXT_String, cc.tc.Dstring_constructor, DontEnum);
+        Put(cc, TEXT_Boolean, cc.tc.Dboolean_constructor, DontEnum);
+        Put(cc, TEXT_Number, cc.tc.Dnumber_constructor, DontEnum);
+        Put(cc, TEXT_Date, cc.tc.Ddate_constructor, DontEnum);
+        Put(cc, TEXT_RegExp, cc.tc.Dregexp_constructor, DontEnum);
+        Put(cc, TEXT_Error, cc.tc.Derror_constructor, DontEnum);
 
-        foreach(d_string key, Dfunction ctor; ctorTable)
+        foreach(d_string key, Dfunction ctor; cc.tc.ctorTable)
         {
             Put(cc, key, ctor, DontEnum);
         }
 
         // Other properties
 
-        assert(Dmath_object);
-        Put(cc, TEXT_Math, Dmath_object, DontEnum);
+        assert(cc.tc.Dmath_object);
+        Put(cc, TEXT_Math, cc.tc.Dmath_object, DontEnum);
 
         // Build an "arguments" property out of argv[],
         // and add it to the global object.

--- a/engine/source/dmdscript/dmath.d
+++ b/engine/source/dmdscript/dmath.d
@@ -288,7 +288,7 @@ class Dmath : Dobject
 {
     this(CallContext* cc)
     {
-        super(cc, Dobject_prototype);
+        super(cc, cc.tc.Dobject_prototype);
 
         //writef("Dmath::Dmath(%x)\n", this);
         uint attributes = DontEnum | DontDelete | ReadOnly;
@@ -346,7 +346,7 @@ class Dmath : Dobject
 
     static void initialize(CallContext* cc)
     {
-        Dmath_object = new Dmath(cc);
+        cc.tc.Dmath_object = new Dmath(cc);
     }
 }
 

--- a/engine/source/dmdscript/dnative.d
+++ b/engine/source/dmdscript/dnative.d
@@ -64,7 +64,7 @@ class DnativeFunction : Dfunction
 
     static void initialize(Dobject o, CallContext* cc, NativeFunctionData[] nfd, uint attributes)
     {
-        Dobject f = Dfunction.getPrototype();
+        Dobject f = Dfunction.getPrototype(cc);
 
         for(size_t i = 0; i < nfd.length; i++)
         {

--- a/engine/source/dmdscript/dnumber.d
+++ b/engine/source/dmdscript/dnumber.d
@@ -37,7 +37,7 @@ class DnumberConstructor : Dfunction
 {
     this(CallContext* cc)
     {
-        super(cc, 1, Dfunction_prototype);
+        super(cc, 1, cc.tc.Dfunction_prototype);
         uint attributes = DontEnum | DontDelete | ReadOnly;
 
         name = TEXT_Number;
@@ -629,12 +629,12 @@ class DnumberPrototype : Dnumber
 {
     this(CallContext* cc)
     {
-        super(cc, Dobject_prototype);
+        super(cc, cc.tc.Dobject_prototype);
         uint attributes = DontEnum;
 
-        Dobject f = Dfunction_prototype;
+        Dobject f = cc.tc.Dfunction_prototype;
 
-        Put(cc, TEXT_constructor, Dnumber_constructor, attributes);
+        Put(cc, TEXT_constructor, cc.tc.Dnumber_constructor, attributes);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -658,7 +658,7 @@ class Dnumber : Dobject
 {
     this(CallContext* cc, d_number n)
     {
-        super(cc, getPrototype());
+        super(cc, getPrototype(cc));
         classname = TEXT_Number;
         value.putVnumber(n);
     }
@@ -670,22 +670,22 @@ class Dnumber : Dobject
         value.putVnumber(0);
     }
 
-    static Dfunction getConstructor()
+    static Dfunction getConstructor(CallContext* cc)
     {
-        return Dnumber_constructor;
+        return cc.tc.Dnumber_constructor;
     }
 
-    static Dobject getPrototype()
+    static Dobject getPrototype(CallContext* cc)
     {
-        return Dnumber_prototype;
+        return cc.tc.Dnumber_prototype;
     }
 
     static void initialize(CallContext* cc)
     {
-        Dnumber_constructor = new DnumberConstructor(cc);
-        Dnumber_prototype = new DnumberPrototype(cc);
+        cc.tc.Dnumber_constructor = new DnumberConstructor(cc);
+        cc.tc.Dnumber_prototype = new DnumberPrototype(cc);
 
-        Dnumber_constructor.Put(cc, TEXT_prototype, Dnumber_prototype, DontEnum | DontDelete | ReadOnly);
+        cc.tc.Dnumber_constructor.Put(cc, TEXT_prototype, cc.tc.Dnumber_prototype, DontEnum | DontDelete | ReadOnly);
     }
 }
 

--- a/engine/source/dmdscript/dobject.d
+++ b/engine/source/dmdscript/dobject.d
@@ -61,9 +61,9 @@ class DobjectConstructor : Dfunction
 {
     this(CallContext* cc)
     {
-        super(cc, 1, Dfunction_prototype);
-        if(Dobject_prototype)
-            Put(cc, TEXT_prototype, Dobject_prototype, DontEnum | DontDelete | ReadOnly);
+        super(cc, 1, cc.tc.Dfunction_prototype);
+        if(cc.tc.Dobject_prototype)
+            Put(cc, TEXT_prototype, cc.tc.Dobject_prototype, DontEnum | DontDelete | ReadOnly);
     }
 
     override void *Construct(CallContext *cc, Value *ret, Value[] arglist)
@@ -74,7 +74,7 @@ class DobjectConstructor : Dfunction
         // ECMA 15.2.2
         if(arglist.length == 0)
         {
-            o = new Dobject(cc, Dobject.getPrototype());
+            o = new Dobject(cc, Dobject.getPrototype(cc));
         }
         else
         {
@@ -83,7 +83,7 @@ class DobjectConstructor : Dfunction
             {
                 if(v.isUndefinedOrNull())
                 {
-                    o = new Dobject(cc, Dobject.getPrototype());
+                    o = new Dobject(cc, Dobject.getPrototype(cc));
                 }
                 else
                     o = v.toObject(cc);
@@ -678,26 +678,26 @@ class Dobject
         return null;
     }
 
-    static Dfunction getConstructor()
+    static Dfunction getConstructor(CallContext* cc)
     {
-        return Dobject_constructor;
+        return cc.tc.Dobject_constructor;
     }
 
-    static Dobject getPrototype()
+    static Dobject getPrototype(CallContext* cc)
     {
-        return Dobject_prototype;
+        return cc.tc.Dobject_prototype;
     }
 
     static void initialize(CallContext* cc)
     {
-        Dobject_prototype = new DobjectPrototype(cc);
+        cc.tc.Dobject_prototype = new DobjectPrototype(cc);
         Dfunction.initialize(cc);
-        Dobject_constructor = new DobjectConstructor(cc);
+        cc.tc.Dobject_constructor = new DobjectConstructor(cc);
 
-        Dobject op = Dobject_prototype;
-        Dobject f = Dfunction_prototype;
+        Dobject op = cc.tc.Dobject_prototype;
+        Dobject f = cc.tc.Dfunction_prototype;
 
-        op.Put(cc, TEXT_constructor, Dobject_constructor, DontEnum);
+        op.Put(cc, TEXT_constructor, cc.tc.Dobject_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -722,7 +722,7 @@ class Dobject
 void dobject_init(CallContext* cc)
 {
     //writef("dobject_init(tc = %x)\n", cast(uint)tc);
-    if(Dobject_prototype)
+    if(cc.tc.Dobject_prototype)
         return;                 // already initialized for this thread
 
     version(none)
@@ -746,9 +746,8 @@ void dobject_init(CallContext* cc)
     Derror.initialize(cc);
 	
 	// Call registered initializer for each object type
-    foreach(fpinit; threadInitTable)
+    foreach(fpinit; cc.tc.threadInitTable)
         fpinit(cc);
-	
 }
 /*Not used anyway
 void dobject_term()

--- a/engine/source/dmdscript/dregexp.d
+++ b/engine/source/dmdscript/dregexp.d
@@ -56,7 +56,7 @@ class DregexpConstructor : Dfunction
 
     this(CallContext* cc)
     {
-        super(cc, 2, Dfunction_prototype);
+        super(cc, 2, cc.tc.Dfunction_prototype);
 
         Value v;
         v.putVstring(null);
@@ -386,12 +386,12 @@ class DregexpPrototype : Dregexp
 {
     this(CallContext* cc)
     {
-        super(cc, Dobject_prototype);
+        super(cc, cc.tc.Dobject_prototype);
         classname = TEXT_Object;
         uint attributes = ReadOnly | DontDelete | DontEnum;
-        Dobject f = Dfunction_prototype;
+        Dobject f = cc.tc.Dfunction_prototype;
 
-        Put(cc, TEXT_constructor, Dregexp_constructor, attributes);
+        Put(cc, TEXT_constructor, cc.tc.Dregexp_constructor, attributes);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -421,7 +421,7 @@ class Dregexp : Dobject
 
     this(CallContext* cc, d_string pattern, d_string attributes)
     {
-        super(cc, getPrototype());
+        super(cc, getPrototype(cc));
 
         Value v;
         v.putVstring(null);
@@ -533,13 +533,13 @@ class Dregexp : Dobject
             {
                 Dfunction df;
 
-                df = Dregexp.getConstructor();
+                df = Dregexp.getConstructor(cc);
                 s = (cast(DregexpConstructor)df).input.string;
             }
 
             dr = cast(Dregexp)othis;
             r = dr.re;
-            dc = cast(DregexpConstructor)Dregexp.getConstructor();
+            dc = cast(DregexpConstructor)Dregexp.getConstructor(cc);
 
             // Decide if we are multiline
             if(dr.multiline.dbool)
@@ -695,31 +695,31 @@ class Dregexp : Dobject
         return null;
     }
 
-    static Dfunction getConstructor()
+    static Dfunction getConstructor(CallContext* cc)
     {
-        return Dregexp_constructor;
+        return cc.tc.Dregexp_constructor;
     }
 
-    static Dobject getPrototype()
+    static Dobject getPrototype(CallContext* cc)
     {
-        return Dregexp_prototype;
+        return cc.tc.Dregexp_prototype;
     }
 
     static void initialize(CallContext* cc)
     {
-        Dregexp_constructor = new DregexpConstructor(cc);
-        Dregexp_prototype = new DregexpPrototype(cc);
+        cc.tc.Dregexp_constructor = new DregexpConstructor(cc);
+        cc.tc.Dregexp_prototype = new DregexpPrototype(cc);
 
         version(none)
         {
-            writef("Dregexp_constructor = %x\n", Dregexp_constructor);
+            writef("Dregexp_constructor = %x\n", cc.tc.Dregexp_constructor);
             uint *p;
-            p = cast(uint *)Dregexp_constructor;
+            p = cast(uint *)cc.tc.Dregexp_constructor;
             writef("p = %x\n", p);
             if(p)
                 writef("*p = %x, %x, %x, %x\n", p[0], p[1], p[2], p[3]);
         }
 
-        Dregexp_constructor.Put(cc, TEXT_prototype, Dregexp_prototype, DontEnum | DontDelete | ReadOnly);
+        cc.tc.Dregexp_constructor.Put(cc, TEXT_prototype, cc.tc.Dregexp_prototype, DontEnum | DontDelete | ReadOnly);
     }
 }

--- a/engine/source/dmdscript/dstring.d
+++ b/engine/source/dmdscript/dstring.d
@@ -82,7 +82,7 @@ class DstringConstructor : Dfunction
 {
     this(CallContext* cc)
     {
-        super(cc, 1, Dfunction_prototype);
+        super(cc, 1, cc.tc.Dfunction_prototype);
         name = "String";
 
         static enum NativeFunctionData[] nfd =
@@ -437,7 +437,7 @@ void* Dstring_prototype_match(Dobject pthis, CallContext *cc, Dobject othis, Val
         Value regret;
 
         regret.putVobject(null);
-        Dregexp.getConstructor().Construct(cc, &regret, arglist);
+        Dregexp.getConstructor(cc).Construct(cc, &regret, arglist);
         o = regret.object;
     }
 
@@ -622,7 +622,7 @@ void* Dstring_prototype_search(Dobject pthis, CallContext *cc, Dobject othis, Va
         Value regret;
 
         regret.putVobject(null);
-        Dregexp.getConstructor().Construct(cc, &regret, arglist);
+        Dregexp.getConstructor(cc).Construct(cc, &regret, arglist);
         o = regret.object;
     }
 
@@ -1164,9 +1164,9 @@ class DstringPrototype : Dstring
 {
     this(CallContext* cc)
     {
-        super(cc, Dobject_prototype);
+        super(cc, cc.tc.Dobject_prototype);
 
-        Put(cc, TEXT_constructor, Dstring_constructor, DontEnum);
+        Put(cc, TEXT_constructor, cc.tc.Dstring_constructor, DontEnum);
 
         static enum NativeFunctionData[] nfd =
         [
@@ -1214,7 +1214,7 @@ class Dstring : Dobject
 {
     this(CallContext* cc, d_string s)
     {
-        super(cc, getPrototype());
+        super(cc, getPrototype(cc));
         classname = TEXT_String;
 
         Put(cc, TEXT_length, std.utf.toUCSindex(s, s.length), DontEnum | DontDelete | ReadOnly);
@@ -1232,19 +1232,19 @@ class Dstring : Dobject
 
     static void initialize(CallContext* cc)
     {
-        Dstring_constructor = new DstringConstructor(cc);
-        Dstring_prototype = new DstringPrototype(cc);
+        cc.tc.Dstring_constructor = new DstringConstructor(cc);
+        cc.tc.Dstring_prototype = new DstringPrototype(cc);
 
-        Dstring_constructor.Put(cc, TEXT_prototype, Dstring_prototype, DontEnum | DontDelete | ReadOnly);
+        cc.tc.Dstring_constructor.Put(cc, TEXT_prototype, cc.tc.Dstring_prototype, DontEnum | DontDelete | ReadOnly);
     }
 
-    static Dfunction getConstructor()
+    static Dfunction getConstructor(CallContext* cc)
     {
-        return Dstring_constructor;
+        return cc.tc.Dstring_constructor;
     }
 
-    static Dobject getPrototype()
+    static Dobject getPrototype(CallContext* cc)
     {
-        return Dstring_prototype;
+        return cc.tc.Dstring_prototype;
     }
 }

--- a/engine/source/dmdscript/extending.d
+++ b/engine/source/dmdscript/extending.d
@@ -134,7 +134,7 @@ class Wrap(Which,string ClassName,Base=Dobject): Base{
     static Constructor _constructor;
     static class Constructor: Dfunction{
         this(CallContext* cc){
-            super(cc, ConstructorArgs.length, Dfunction_prototype);
+            super(cc, ConstructorArgs.length, cc.tc.Dfunction_prototype);
             name = ClassName;
         }
 
@@ -151,7 +151,7 @@ class Wrap(Which,string ClassName,Base=Dobject): Base{
     
     }
     static void initialize(CallContext* cc){
-         _prototype = new Wrap(cc, Base.getPrototype());
+         _prototype = new Wrap(cc, Base.getPrototype(cc));
         _constructor = new Constructor(cc);
         _prototype.Put(cc, "constructor", _constructor, DontEnum);
         _constructor.Put(cc, "prototype", _prototype, DontEnum | DontDelete | ReadOnly);

--- a/engine/source/dmdscript/opcodes.d
+++ b/engine/source/dmdscript/opcodes.d
@@ -446,7 +446,7 @@ struct IR
                     {
                         ca = cast(Catch)o;
                         //writef("catch('%s')\n", ca.name);
-                        o = new Dobject(cc, Dobject.getPrototype());
+                        o = new Dobject(cc, Dobject.getPrototype(cc));
                         version(JSCRIPT_CATCH_BUG)
                         {
                             PutValue(cc, ca.name, a);

--- a/engine/source/dmdscript/program.d
+++ b/engine/source/dmdscript/program.d
@@ -34,6 +34,7 @@ import dmdscript.parse;
 import dmdscript.scopex;
 import dmdscript.text;
 import dmdscript.property;
+import dmdscript.protoerror;
 
 class Program
 {
@@ -61,6 +62,8 @@ class Program
 
         CallContext *cc = callcontext;
 
+        initErrors(cc);
+
         // Do object inits
         dobject_init(cc);
 
@@ -77,7 +80,7 @@ class Program
         cc.scoperoot++;
         cc.globalroot++;
 
-        assert(Ddate_prototype.proptable.table.length != 0);
+        assert(cc.tc.Ddate_prototype.proptable.table.length != 0);
     }
 
     /**************************************************
@@ -88,6 +91,14 @@ class Program
 
     void compile(d_string progIdentifier, d_string srctext, FunctionDefinition *pfd)
     {
+        // initialize methods registered by dscript.extending
+        if (!threadInitTableRan)
+        {
+            threadInitTableRan = true;
+            foreach(fpinit; threadInitTable)
+                fpinit(callcontext);
+        }
+
         TopStatement[] topstatements;
         d_string msg;
 

--- a/engine/source/dmdscript/protoerror.d
+++ b/engine/source/dmdscript/protoerror.d
@@ -35,7 +35,7 @@ class D0_constructor : Dfunction
 
     this(CallContext* cc, d_string text_d1, Dobject function(CallContext* cc, d_string) newD0)
     {
-        super(cc, 1, Dfunction_prototype);
+        super(cc, 1, cc.tc.Dfunction_prototype);
         this.text_d1 = text_d1;
         this.newD0 = newD0;
     }
@@ -74,11 +74,11 @@ template proto(alias TEXT_D1)
     {
         this(CallContext* cc)
         {
-            super(cc, Derror_prototype);
+            super(cc, cc.tc.Derror_prototype);
 
             d_string s;
 
-            Put(cc, TEXT_constructor, ctorTable[TEXT_D1], DontEnum);
+            Put(cc, TEXT_constructor, cc.tc.ctorTable[TEXT_D1], DontEnum);
             Put(cc, TEXT_name, TEXT_D1, 0);
             s = TEXT_D1 ~ ".prototype.message";
             Put(cc, TEXT_message, s, 0);
@@ -101,7 +101,7 @@ template proto(alias TEXT_D1)
 
         this(CallContext* cc, d_string m)
         {
-            this(cc, D0.getPrototype());
+            this(cc, D0.getPrototype(cc));
             Put(cc, TEXT_message, m, 0);
             Put(cc, TEXT_description, m, 0);
             Put(cc, TEXT_number, cast(d_number)0, 0);
@@ -124,14 +124,14 @@ template proto(alias TEXT_D1)
             //writefln("getErrInfo(linnum = %d), errinfo.linnum = %d", linnum, errinfo.linnum);
         }
 
-        static Dfunction getConstructor()
+        static Dfunction getConstructor(CallContext* cc)
         {
-            return ctorTable[TEXT_D1];
+            return cc.tc.ctorTable[TEXT_D1];
         }
 
-        static Dobject getPrototype()
+        static Dobject getPrototype(CallContext* cc)
         {
-            return protoTable[TEXT_D1];
+            return cc.tc.protoTable[TEXT_D1];
         }
 
         static Dobject newD0(CallContext* cc, d_string s)
@@ -142,10 +142,10 @@ template proto(alias TEXT_D1)
         static void init(CallContext* cc)
         {
             Dfunction constructor = new D0_constructor(cc, TEXT_D1, &newD0);
-            ctorTable[TEXT_D1] = constructor;
+            cc.tc.ctorTable[TEXT_D1] = constructor;
 
             Dobject prototype = new D0_prototype(cc);
-            protoTable[TEXT_D1] = prototype;
+            cc.tc.protoTable[TEXT_D1] = prototype;
 
             constructor.Put(cc, TEXT_prototype, prototype, DontEnum | DontDelete | ReadOnly);
         }
@@ -163,14 +163,12 @@ alias proto!(TEXT_URIError) urierror;
  * Register initializer for each class.
  */
 
-static this()
+void initErrors(CallContext* cc)
 {
-    import std.functional : toDelegate;
-
-    threadInitTable ~= toDelegate(&syntaxerror.D0.init);
-    threadInitTable ~= toDelegate(&evalerror.D0.init);
-    threadInitTable ~= toDelegate(&referenceerror.D0.init);
-    threadInitTable ~= toDelegate(&rangeerror.D0.init);
-    threadInitTable ~= toDelegate(&typeerror.D0.init);
-    threadInitTable ~= toDelegate(&urierror.D0.init);
+    cc.tc.threadInitTable ~= &syntaxerror.D0.init;
+    cc.tc.threadInitTable ~= &evalerror.D0.init;
+    cc.tc.threadInitTable ~= &referenceerror.D0.init;
+    cc.tc.threadInitTable ~= &rangeerror.D0.init;
+    cc.tc.threadInitTable ~= &typeerror.D0.init;
+    cc.tc.threadInitTable ~= &urierror.D0.init;
 }

--- a/engine/source/dmdscript/script.d
+++ b/engine/source/dmdscript/script.d
@@ -82,6 +82,7 @@ import dmdscript.value;
 import dmdscript.dobject;
 import dmdscript.program;
 import dmdscript.text;
+import dmdscript.threadcontext;
 import dmdscript.functiondefinition;
 
 struct CallContext
@@ -103,6 +104,9 @@ struct CallContext
     uint               linnum;     // source line number of exception (1 based, 0 if not available)
 
     int                Interrupt;  // !=0 if cancelled due to interrupt
+
+    // these used to be TLS variables and are now tied to the context
+    ThreadContext tc;
 }
 
 struct Global

--- a/engine/source/dmdscript/threadcontext.d
+++ b/engine/source/dmdscript/threadcontext.d
@@ -28,40 +28,44 @@ import dmdscript.dfunction;
 // These are our per-thread global variables
 // Tables where the prototype and constructor object are stored.
 
-Dobject[d_string] protoTable;
-Dfunction[d_string] ctorTable;
+struct ThreadContext {
+	Dobject[d_string] protoTable;
+	Dfunction[d_string] ctorTable;
 
-Dfunction Dobject_constructor;
-Dobject Dobject_prototype;
+	Dfunction Dobject_constructor;
+	Dobject Dobject_prototype;
 
-Dfunction Dfunction_constructor;
-Dobject Dfunction_prototype;
+	Dfunction Dfunction_constructor;
+	Dobject Dfunction_prototype;
 
-Dfunction Darray_constructor;
-Dobject Darray_prototype;
+	Dfunction Darray_constructor;
+	Dobject Darray_prototype;
 
-Dfunction Dstring_constructor;
-Dobject Dstring_prototype;
+	Dfunction Dstring_constructor;
+	Dobject Dstring_prototype;
 
-Dfunction Dboolean_constructor;
-Dobject Dboolean_prototype;
+	Dfunction Dboolean_constructor;
+	Dobject Dboolean_prototype;
 
-Dfunction Dnumber_constructor;
-Dobject Dnumber_prototype;
+	Dfunction Dnumber_constructor;
+	Dobject Dnumber_prototype;
 
-Dfunction Derror_constructor;
-Dobject Derror_prototype;
+	Dfunction Derror_constructor;
+	Dobject Derror_prototype;
 
-Dfunction Ddate_constructor;
-Dobject Ddate_prototype;
+	Dfunction Ddate_constructor;
+	Dobject Ddate_prototype;
 
-Dfunction Dregexp_constructor;
-Dobject Dregexp_prototype;
+	Dfunction Dregexp_constructor;
+	Dobject Dregexp_prototype;
 
-Dfunction Denumerator_constructor;
-Dobject Denumerator_prototype;
+	Dfunction Denumerator_constructor;
+	Dobject Denumerator_prototype;
 
-Dmath Dmath_object;
+	Dmath Dmath_object;
+
+	void function (CallContext*)[] threadInitTable;
+}
 
 // kept for backwards compatibility with the dmdscript.extending module
 void delegate (CallContext*)[] threadInitTable;


### PR DESCRIPTION
This removes all remaining non-constant global variables, with the exception of `threadInitTable` to support the existing semantics of `dmdscript.extending`.