### PR TITLE
Fix deprecation warnings and errors.

### DIFF
--- a/ds-ext/dub.json
+++ b/ds-ext/dub.json
@@ -4,8 +4,8 @@
     "copyright": "Copyright (c) 2000-2002 by Chromium Communications, Copyright (c) 2004-2010 by Digital Mars",
     "authors": ["Walter Bright", "Dmitry Olshansky"],
     "dependencies": {
-        "dmdscript:engine" : "*"
+        "dmdscript:engine": { "path": ".." }
     },
     "targetType": "executable",
-    "license": "BSL-1.0",
+    "license": "BSL-1.0"
 }

--- a/ds-ext/source/ext.d
+++ b/ds-ext/source/ext.d
@@ -18,6 +18,7 @@ struct A{
                          
 
 void main(){
+    static import std.file;
     Program p = new Program;
     extendGlobal!func(p,"mul");
     auto src  = cast(string)std.file.read("ext.ds");

--- a/ds/dub.json
+++ b/ds/dub.json
@@ -4,8 +4,8 @@
     "copyright": "Copyright (c) 2000-2002 by Chromium Communications, Copyright (c) 2004-2010 by Digital Mars",
     "authors": ["Walter Bright", "Dmitry Olshansky"],
     "dependencies": {
-        "dmdscript:engine" : "*"
+        "dmdscript:engine": { "path": ".." }
     },
     "targetType": "executable",
-    "license": "BSL-1.0",
+    "license": "BSL-1.0"
 }

--- a/engine/source/dmdscript/darray.d
+++ b/engine/source/dmdscript/darray.d
@@ -753,8 +753,8 @@ void *Darray_prototype_sort(Dobject pthis, CallContext *cc, Dobject othis, Value
         }
     }
 
-    delete p1;
-    delete p2;
+    destroy(p1);
+    destroy(p2);
 
     ret.putVobject(othis);
     return null;

--- a/engine/source/dmdscript/ddeclaredfunction.d
+++ b/engine/source/dmdscript/ddeclaredfunction.d
@@ -148,7 +148,7 @@ class DdeclaredFunction : Dfunction
 
         result = IR.call(cc, othis, fd.code, ret, locals.ptr);
 
-        delete p1;
+        destroy(p1);
 
         cc.callerf = callerfsave;
         cc.caller = callersave;

--- a/engine/source/dmdscript/dfunction.d
+++ b/engine/source/dmdscript/dfunction.d
@@ -224,7 +224,7 @@ void* Dfunction_prototype_apply(Dobject pthis, CallContext *cc, Dobject othis, V
 
         v = othis.Call(cc, o, ret, alist);
 
-        delete p1;
+        destroy(p1);
     }
     return v;
 }

--- a/engine/source/dmdscript/dglobal.d
+++ b/engine/source/dmdscript/dglobal.d
@@ -131,7 +131,7 @@ void* Dglobal_eval(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Va
         // calling context.
         result = IR.call(cc, othis, fd.code, ret, locals);
 
-        delete p1;
+        destroy(p1);
         cc.variable = variablesave;
         cc.scopex = scopesave;
         return result;
@@ -155,7 +155,7 @@ void* Dglobal_eval(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, Va
         assert(cc.callerothis);
         result = IR.call(cc, cc.callerothis, fd.code, ret, locals.ptr);
         if(p1)
-            delete p1;
+            destroy(p1);
         fd = null;
         // if (result) writef("result = '%s'\n", (cast(Value* )result).toString());
         return result;

--- a/engine/source/dmdscript/irstate.d
+++ b/engine/source/dmdscript/irstate.d
@@ -164,7 +164,7 @@ struct IRstate
 
     void gen0(Loc loc, uint opcode)
     {
-        codebuf.write(combine(loc, opcode));
+        codebuf.write(cast(ulong)combine(loc, opcode));
     }
 
     void gen1(Loc loc, uint opcode, Op arg)
@@ -485,7 +485,7 @@ struct IRstate
             }
         }
 
-        delete p1;
+        destroy(p1);
 
         //return;
         // Remove all IRnop's

--- a/engine/source/dmdscript/iterator.d
+++ b/engine/source/dmdscript/iterator.d
@@ -82,7 +82,7 @@ struct Iterator
         {
             while(keyindex == keys.length)
             {
-                delete keys;
+                destroy(keys);
                 o = getPrototype(o);
                 if(!o)
                     return null;

--- a/engine/source/dmdscript/parse.d
+++ b/engine/source/dmdscript/parse.d
@@ -98,7 +98,7 @@ class Parser : Lexer
         if(p.errinfo.message)
             goto Lreturn;
 
-        delete p;
+        destroy(p);
 
         // Parse StatementList
         p = new Parser("anonymous", bdy, 0);
@@ -119,7 +119,7 @@ class Parser : Lexer
         pfd = fd;
         perrinfo = p.errinfo;
         result = (p.errinfo.message != null);
-        delete p;
+        destroy(p);
         p = null;
         return result;
     }

--- a/engine/source/dmdscript/program.d
+++ b/engine/source/dmdscript/program.d
@@ -222,13 +222,13 @@ class Program
 
             result.getErrInfo(&errinfo, cc.linnum);
             cc.linnum = 0;
-            delete p1;
+            destroy(p1);
             throw new ScriptException(&errinfo);
         }
         //writef("-Program.execute()\n");
 
 
-        delete p1;
+        destroy(p1);
     }
 
     void toBuffer(ref tchar[] buf)


### PR DESCRIPTION
There were a few compilation errors due to depending on the latest
version of dmdscript published to dub, which uses implicit string
concatenation. This changes the project to use its own source tree for
dependencies between subprojects.

This change also removes usages of the deprecated `delete` keyword.