### PR TITLE
Fix testsuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: Test Suite
+
+# Only triggers on pushes/PRs to master
+on:
+    pull_request:
+        branches:
+            - master
+    push:
+        branches:
+            - master
+
+jobs:
+    test:
+        name: CI
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+                dc: [dmd-latest, ldc-latest, ldc-1.15.0]
+                arch: [x86, x86_64]
+
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Install D compiler
+              uses: dlang-community/setup-dlang@v1
+              with:
+                  compiler: ${{ matrix.dc }}
+
+            - name: Run tests
+              env:
+                CONFIG: ${{matrix.config}}
+                ARCH: ${{matrix.arch}}
+              shell: bash
+              run: dub test :engine
+    testsuite:
+        name: Test262
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest]
+                dc: [dmd-latest]
+                arch: [x86_64]
+
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Install D compiler
+              uses: dlang-community/setup-dlang@v1
+              with:
+                  compiler: ${{ matrix.dc }}
+
+            - name: Run tests
+              env:
+                CONFIG: ${{matrix.config}}
+                ARCH: ${{matrix.arch}}
+              shell: bash
+              run: ./run-test262.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: d
-sudo: false
-
-script:
-  - ./build.sh
-  - ./run-test262.sh

--- a/ds-ext/source/ext.d
+++ b/ds-ext/source/ext.d
@@ -2,9 +2,9 @@ import dmdscript.program;
 import dmdscript.script;
 import dmdscript.extending;
 
+import std.file;
 import std.stdio;
 import std.typecons;
-import std.stdio;
 
 int func(int a,int b){ return a*b;  }
                    

--- a/run-test262.sh
+++ b/run-test262.sh
@@ -1,27 +1,33 @@
 #!/bin/bash
-set -e
+set -xe
 
 ./build.sh
 
 if ! [ -d test262 ] ; then
     echo "Cloning test262 test suite..."
     git clone https://github.com/tc39/test262.git
+    cd test262
+    git checkout a456b0a390bb0f70b4cb8d38cb5ab0ecb557a851
+    cd ..
     echo "Applying patch to make the harness ES3/5 compatible..."
     sed 's/  let /  var /g' -i test262/harness/assert.js
 fi
 if ! [ -d test262-harness-py ] ; then
     echo "Cloning the console test runner..."
     git clone https://github.com/test262-utils/test262-harness-py.git
+    cd test262-harness-py
+    git checkout 0f2acdd882c84cff43b9d60df7574a1901e2cdcd
+    cd ..
     echo "Applying patch to adjust the runner for the latest version of the test suite..."
     sed '/self\.suite\.GetInclude("cth\.js")/d' -i test262-harness-py/src/test262.py
 fi
 
 echo "Running the test suite..."
 cd test262-harness-py
-src/test262.py --summary --non_strict_only --command ../timed-dmdscript.sh --tests=../test262 | tee ../dmdscript-test262.log | grep '=== .* failed in .* ==='
+python2 src/test262.py --summary --non_strict_only --command ../timed-dmdscript.sh --tests=../test262 | tee ../dmdscript-test262.log | grep '=== .* failed in .* ==='
 cd ..
 
-EXPECTED_TO_PASS=5238
+EXPECTED_TO_PASS=5223
 PASSED=$(grep ' - Passed [0-9]* tests' dmdscript-test262.log | sed -n 's/.*Passed \([0-9]*\) tests.*/\1/;P')
 
 if [ "$PASSED" -gt "$EXPECTED_TO_PASS" ]; then

--- a/run-test262.sh
+++ b/run-test262.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+./build.sh
+
 if ! [ -d test262 ] ; then
     echo "Cloning test262 test suite..."
     git clone https://github.com/tc39/test262.git


### PR DESCRIPTION
The test suite has been broken for a long time and I decided to give this another go. It now pins the test suite to a certain commit, so that the test cases that are run are fixed and the test suite itself doesn't use feature that are not supported by DMDScript.

This also switches to GitHub actions.