### PR TITLE
Fix iOS compilation.

### DIFF
--- a/engine/source/dmdscript/dglobal.d
+++ b/engine/source/dmdscript/dglobal.d
@@ -661,6 +661,12 @@ void* Dglobal_readln(Dobject pthis, CallContext *cc, Dobject othis, Value* ret, 
             if(c == EOF)
                 break;
         }
+	else version(iOS)
+        {
+            c = core.stdc.stdio.getchar();
+            if(c == EOF)
+                break;
+        }
         else version(FreeBSD)
         {
             c = core.stdc.stdio.getchar();


### PR DESCRIPTION
This is the only reason why the iOS version doesn't compile. Otherwise it works in the same way as MacOS.