### PR TITLE
Force reinterpret-cast to reverse the cast in FunctionDefinition.semantic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
               run: ./run-test262.sh
 
             - name: Upload log
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               if: always()
               with:
                 name: runtest262 log

--- a/engine/source/dmdscript/expression.d
+++ b/engine/source/dmdscript/expression.d
@@ -608,7 +608,7 @@ class FunctionLiteral : Expression
 
   override Expression semantic(Scope *sc)
   {
-      func = cast(FunctionDefinition)(func.semantic(sc));
+      func = cast(FunctionDefinition)cast(void*)func.semantic(sc);
       return this;
   }
 

--- a/run-test262.sh
+++ b/run-test262.sh
@@ -29,7 +29,7 @@ cd test262-harness-py
 python3 src/test262.py --summary --non_strict_only --command ../timed-dmdscript.sh --tests=../test262 | tee ../dmdscript-test262.log | grep -a '=== .* failed in .* ==='
 cd ..
 
-EXPECTED_TO_PASS=5238
+EXPECTED_TO_PASS=5239
 PASSED=$(grep -a ' - Passed [0-9]* tests' dmdscript-test262.log | sed -n 's/.*Passed \([0-9]*\) tests.*/\1/;P')
 
 if [ "$PASSED" -gt "$EXPECTED_TO_PASS" ]; then

--- a/test262-patches/test262-parseTestRecord.py.patch
+++ b/test262-patches/test262-parseTestRecord.py.patch
@@ -2,6 +2,15 @@ diff --git "a/src/parseTestRecord.py" "b/src/parseTestRecord.py"
 index 22d5664..5be3a5f 100644
 --- "a/src/parseTestRecord.py"
 +++ "b/src/parseTestRecord.py"
+@@ -16,7 +16,7 @@
+ import sys
+ import tempfile
+ import time
+-import imp
++import importlib
+ 
+ from _monkeyYaml import load as yamlLoad
+ 
 @@ -78,7 +78,7 @@ def yamlAttrParser(testRecord, attrs, name):
      parsed = yamlLoad(body)
  


### PR DESCRIPTION
With LDC 1.42.0, the direct cast from Statement to FunctionDefintion returns null, causing a segmentation fault later on. Casting to void* first forces a reinterpret cast and is symmetric with the code in [`FunctionDefinition.semantic()`](https://github.com/DigitalMars/DMDScript/blob/f93cb97b5ec1c665648f369b0fb96ff82155cdfb/engine/source/dmdscript/functiondefinition.d#L162).